### PR TITLE
Change internet labelling orientation/format prompts and add example images for orientation

### DIFF
--- a/src/main/java/uk/co/fivium/els/categories/internetlabelling/model/InternetLabelOrientation.java
+++ b/src/main/java/uk/co/fivium/els/categories/internetlabelling/model/InternetLabelOrientation.java
@@ -1,8 +1,8 @@
 package uk.co.fivium.els.categories.internetlabelling.model;
 
 public enum InternetLabelOrientation {
-  LEFT("Pointing left"),
-  RIGHT("Pointing right");
+  LEFT("Pointing left <svg style=\"color: #00A64F; vertical-align: -4px; margin-left: 5px;\" role=\"presentation\" focusable=\"false\" xmlns=\"http://www.w3.org/2000/svg\" viewbox=\"0 0 50 20\" height=\"20\" width=\"50\"><path fill=\"currentColor\" d=\"M10 0 50 0 50 20 10 20 0 10 10 0\"/></svg>"),
+  RIGHT("Pointing right <svg style=\"color: #00A64F; vertical-align: -4px; margin-left: 5px;\" role=\"presentation\" focusable=\"false\" xmlns=\"http://www.w3.org/2000/svg\" viewbox=\"0 0 50 20\" height=\"20\" width=\"50\"><path fill=\"currentColor\" d=\"M0 0 40 0 50 10 40 20 0 20 0 0\"/></svg>");
 
   private final String displayName;
 

--- a/src/main/java/uk/co/fivium/els/categories/internetlabelling/model/InternetLabellingForm.java
+++ b/src/main/java/uk/co/fivium/els/categories/internetlabelling/model/InternetLabellingForm.java
@@ -8,17 +8,17 @@ import uk.co.fivium.els.model.meta.InternetLabelModeField;
 public class InternetLabellingForm {
 
   @FieldPrompt("Enter height of the product price (in pixels)")
-  @Digits(integer = 2, fraction = 0, groups = InternetLabellingGroup.class, message = "Enter the height of the product price, up to 2 digits long")
+  @Digits(integer = 3, fraction = 0, groups = InternetLabellingGroup.class, message = "Enter the height of the product price, up to 3 digits long")
   @InternetLabelModeField
   private String productPriceHeightPx;
 
-  @FieldPrompt("Label orientation")
-  @NotBlank(groups = InternetLabellingGroup.class, message = "Select a label orientation")
+  @FieldPrompt("Arrow direction")
+  @NotBlank(groups = InternetLabellingGroup.class, message = "Select an arrow direction")
   @InternetLabelModeField
   private String labelOrientation;
 
-  @FieldPrompt("Label format")
-  @NotBlank(groups = InternetLabellingGroup.class, message = "Select a label format")
+  @FieldPrompt("Image format")
+  @NotBlank(groups = InternetLabellingGroup.class, message = "Select an image format")
   @InternetLabelModeField
   private String labelFormat;
 

--- a/src/main/resources/templates/govuk/radio.ftl
+++ b/src/main/resources/templates/govuk/radio.ftl
@@ -35,7 +35,7 @@
             <div class="govuk-radios__item">
             <input class="govuk-radios__input" id="${id}<#if item?counter != 1>-${item}</#if>" name="${fieldName}" type="radio" value="${item}" <#if isSelected>checked="checked"</#if> <#if hiddenContentId?has_content>data-aria-controls="${hiddenContentId}"</#if>>
               <label class="govuk-label govuk-radios__label" for="${id}<#if item?counter != 1>-${item}</#if>">
-                ${radioItems[item]}
+                ${radioItems[item]?no_esc}
               </label>
             </div>
           </#list>


### PR DESCRIPTION
User testing showed that some of the internet labeling prompts were confusing and they weren't sure what selecting 'Pointing left' or 'Pointing right' would do, so we agreed to change the prompts and add small example images in each option:
![image](https://user-images.githubusercontent.com/1935173/55087369-e9900f80-50a1-11e9-932e-c8b1ce16c621.png)

Using SVG to ensure it looks sharp at all zoom levels, and using currentColor in the SVG to ensure it picks up user agent changes to the text color for accessibility (tested in Windows high contrast mode with IE and Firefox custom colours):

![image](https://user-images.githubusercontent.com/1935173/55087502-222fe900-50a2-11e9-92da-a333b3e15905.png)

I've used inline styles on the SVGs as we don't currently have an app stylesheet and I didn't want to introduce an extra HTTP request just for this. I'll move the styling into an app stylesheet if we end up needing one later on.

