### PR TITLE
Change service URL from gov.uk start page to .service.gov.uk domain

### DIFF
--- a/src/main/resources/templates/staticContent/accessibilityStatement.ftl
+++ b/src/main/resources/templates/staticContent/accessibilityStatement.ftl
@@ -3,7 +3,7 @@
 <@defaultPage pageHeading="Accessibility statement for Create an energy label" pageTitle="Accessibility statement">
   <p class="govuk-body">
     This statement applies to content published on the ‘Create an energy label’ service web pages only
-    (<a class="govuk-link" href="https://www.gov.uk/guidance/create-an-energy-label">https://www.gov.uk/guidance/create-an-energy-label</a>)
+    (<a class="govuk-link" href="https://create-energy-label.service.gov.uk">create-energy-label.service.gov.uk</a>)
     (the ‘service’).
   </p>
   <p class="govuk-body">


### PR DESCRIPTION
Changed because the accessibility statement only applies to pages on create-energy-label.service.gov.uk. The start page is on the main GOV.UK domain so isn't covered by this statement