### PR TITLE
Automatically set HTML input field type as 'number' for numeric fields

### DIFF
--- a/src/main/java/uk/gov/beis/els/mvc/FormAnnotationHandlerInterceptor.java
+++ b/src/main/java/uk/gov/beis/els/mvc/FormAnnotationHandlerInterceptor.java
@@ -43,9 +43,8 @@ public class FormAnnotationHandlerInterceptor implements HandlerInterceptor {
         getStaticProductText(form).ifPresent(t -> modelAndView.addObject("staticProductText", t));
         modelAndView.addObject("fieldWidthMapping", getFieldWidthMapping(form));
         addInternetLabelModelObjects(request, modelAndView);
-
         modelAndView.addObject("hiddenFields", getHiddenFields(form, modelAndView));
-
+        modelAndView.addObject("numericFields", getNumericFields(form));
       }
     }
   }
@@ -189,6 +188,24 @@ public class FormAnnotationHandlerInterceptor implements HandlerInterceptor {
         fieldWidths.put(FORM_MODEL_ATTRIBUTE_NAME + "." + name, "2");
       }
     }
+  }
+
+  private List<String> getNumericFields(Object form) {
+    List<String> numericFields = new ArrayList<>();
+    Class<?> formClass = form.getClass();
+
+    ReflectionUtils.doWithFields(formClass, (field -> {
+      String name = field.getName();
+      Digits digitsAnnotation = field.getAnnotation(Digits.class);
+      Pattern patternAnnotation = field.getAnnotation(Pattern.class);
+
+      // Field input should be marked as numeric if it has Digits or a specific Pattern annotation (see comment in processFieldWidthPatternAnnotations)
+      if (digitsAnnotation != null || (patternAnnotation != null && "[0-9]{0,2}".equals(patternAnnotation.regexp()))) {
+        numericFields.add(FORM_MODEL_ATTRIBUTE_NAME + "." + name);
+      }
+
+    }));
+    return numericFields;
   }
 
 }

--- a/src/main/resources/templates/form.ftl
+++ b/src/main/resources/templates/form.ftl
@@ -1,5 +1,6 @@
 <#macro govukForm actionUrl>
-  <form action="${actionUrl}" method="post">
+  <#-- 'novalidate' to disable browser based HTML5 client side form validation -->
+  <form action="${actionUrl}" method="post" novalidate>
     <#nested>
   </form>
 </#macro>

--- a/src/main/resources/templates/govuk/textInput.ftl
+++ b/src/main/resources/templates/govuk/textInput.ftl
@@ -13,6 +13,7 @@
   <#local fieldHint=(fieldPromptMapping[spring.status.path].hintText())!>
   <#local fieldWidth=fieldWidthMapping[spring.status.path]!>
   <#local hiddenField=hiddenFields?seq_contains(spring.status.path)!false>
+  <#local numericField=(numericFields?seq_contains(spring.status.path))!false>
 
   <#if !hiddenField>
     <div class="govuk-form-group <#if hasError>govuk-form-group--error</#if>">
@@ -31,7 +32,7 @@
         </#list>
         </span>
       </#if>
-      <input class="govuk-input <#if fieldWidth?has_content>govuk-input--width-${fieldWidth} </#if> <#if hasError>govuk-input--error </#if>" id="${id}" name="${spring.status.expression}" type="text"  <#if fieldHint?has_content>aria-describedby="${id}-hint" </#if> value="${spring.stringStatusValue}">
+      <input class="govuk-input <#if fieldWidth?has_content>govuk-input--width-${fieldWidth} </#if> <#if hasError>govuk-input--error </#if>" id="${id}" name="${spring.status.expression}" type="<#if numericField>number<#else>text</#if>"  <#if fieldHint?has_content>aria-describedby="${id}-hint" </#if> value="${spring.stringStatusValue}">
     </div>
   </#if>
 


### PR DESCRIPTION
Also disables the browser based HTML5 form validation (which tries to validate numeric input types) as it looks awful in Firefox. GDS also do this on the design-system.