### PR TITLE
Set HTML title so generated label PDF has a title

### DIFF
--- a/src/main/java/uk/gov/beis/els/service/TemplatePopulator.java
+++ b/src/main/java/uk/gov/beis/els/service/TemplatePopulator.java
@@ -134,10 +134,15 @@ public class TemplatePopulator {
 
   public <T extends AnalyticsForm & SupplierNameForm> ProcessedEnergyLabelDocument asProcessedEnergyLabel(
       ProductMetadata analyticsLabel, T form) {
+    String title = String.format(analyticsLabel.getProductFileName() + " - %s - %s",
+      form.getSupplierName(), form.getModelName());
+    TemplateUtils.getElementById(template, "html-title").text(title);
+
     return new ProcessedEnergyLabelDocument(template, analyticsLabel, form.getGoogleAnalyticsClientId(), form.getSupplierName(), form.getModelName());
   }
 
   public ProcessedEnergyLabelDocument asProcessedEnergyLabelNoSupplier(ProductMetadata analyticsLabel, AnalyticsForm form) {
+    TemplateUtils.getElementById(template, "html-title").text(analyticsLabel.getProductFileName());
     return new ProcessedEnergyLabelDocument(template, analyticsLabel, form.getGoogleAnalyticsClientId(), null, null);
   }
 

--- a/src/main/resources/labels/html-wrapper.html
+++ b/src/main/resources/labels/html-wrapper.html
@@ -25,6 +25,7 @@
       }
 
     </style>
+    <title id="html-title"></title>
   </head>
   <body id="root">
   </body>


### PR DESCRIPTION
I've set an `id` on `title` rather than using `getElementsByTag` as by this point there are two title tags, one in the `head` and one inside the SVG. `id` on `title` is valid in HTML5