### PR TITLE
Fix broken path to Opengraph image

### DIFF
--- a/src/main/resources/templates/layout.ftl
+++ b/src/main/resources/templates/layout.ftl
@@ -67,7 +67,7 @@
   <link rel="stylesheet" href="<@spring.url'/assets/static/css/main-ie8.css'/>">
   <![endif]-->
 
-  <meta property="og:image" content="<@spring.url'/assets/govuk-frontend/assets/images/govuk-opengraph-image.png'/>">
+  <meta property="og:image" content="<@spring.url'/assets/govuk-frontend/govuk/assets/images/govuk-opengraph-image.png'/>">
 </head>
 
 <body class="govuk-template__body ">


### PR DESCRIPTION
I've grepped for other `/assets/govuk-frontend` paths and this looks like the only one missing the trailing `/govuk`