### PR TITLE
Enable multline text for supplier and model on rescaled labels (except light sources)

### DIFF
--- a/src/main/java/uk/gov/beis/els/categories/dishwashers/service/DishwashersService.java
+++ b/src/main/java/uk/gov/beis/els/categories/dishwashers/service/DishwashersService.java
@@ -45,8 +45,6 @@ public class DishwashersService {
     if (legislationCategory.equals(LEGISLATION_CATEGORY_PRE_MARCH_2021)) {
       templatePopulator = new TemplatePopulator(templateParserService.parseTemplate("labels/dishwashers/dishwashers-2010.svg"));
       templatePopulator
-          .setMultilineText("supplier", form.getSupplierName())
-          .setMultilineText("model", form.getModelName())
           .setText("placeSettingsCapacity", form.getStandardCapacity())
           .setText("kwhAnnum", form.getAnnualEnergyConsumption())
           .setText("lAnnum", form.getAnnualWaterConsumption())
@@ -55,8 +53,6 @@ public class DishwashersService {
       templatePopulator = new TemplatePopulator(templateParserService.parseTemplate("labels/dishwashers/dishwashers-2021.svg"));
       templatePopulator
           .setQrCode(form)
-          .setText("supplier", form.getSupplierName())
-          .setText("model", form.getModelName())
           .setText("placeSettingsCapacity", form.getEcoCapacity())
           .setText("kwh100cycles", form.getEnergyConsumptionPer100Cycles())
           .setText("lCycle", form.getWaterConsumptionPerCycle())
@@ -65,6 +61,8 @@ public class DishwashersService {
     }
 
     return templatePopulator
+        .setMultilineText("supplier", form.getSupplierName())
+        .setMultilineText("model", form.getModelName())
         .setText("db", form.getNoiseEmissions())
         .setRatingArrow("rating", RatingClass.valueOf(form.getEfficiencyRating()),
             legislationCategory.getPrimaryRatingRange())

--- a/src/main/java/uk/gov/beis/els/categories/refrigeratingappliances/service/RefrigeratingAppliancesService.java
+++ b/src/main/java/uk/gov/beis/els/categories/refrigeratingappliances/service/RefrigeratingAppliancesService.java
@@ -69,10 +69,6 @@ public class RefrigeratingAppliancesService {
         templatePopulator
             .setText("fridgeLitres", "-");
       }
-
-      templatePopulator
-          .setMultilineText("supplier", form.getSupplierName())
-          .setMultilineText("model", form.getModelName());
     } else {
       templatePopulator = new TemplatePopulator(templateParserService.parseTemplate("labels/household-refrigerating-appliances/household-refrigerating-appliances-2021.svg"));
 
@@ -90,12 +86,12 @@ public class RefrigeratingAppliancesService {
 
       templatePopulator
           .setQrCode(form)
-          .applyRatingCssClass("noiseClass", RatingClass.valueOf(form.getNoiseEmissionsClass()))
-          .setText("supplier", form.getSupplierName())
-          .setText("model", form.getModelName());;
+          .applyRatingCssClass("noiseClass", RatingClass.valueOf(form.getNoiseEmissionsClass()));
     }
 
     return templatePopulator
+      .setMultilineText("supplier", form.getSupplierName())
+      .setMultilineText("model", form.getModelName())
       .setRatingArrow("rating", RatingClass.valueOf(form.getEfficiencyRating()), legislationCategory.getPrimaryRatingRange())
       .setText("kwhAnnum", form.getAnnualEnergyConsumption())
       .setText("db", form.getNoiseEmissions())
@@ -107,19 +103,17 @@ public class RefrigeratingAppliancesService {
 
     if (legislationCategory.equals(LEGISLATION_CATEGORY_PRE_MARCH_2021)) {
       templatePopulator = new TemplatePopulator(templateParserService.parseTemplate(
-          "labels/household-refrigerating-appliances/wine-storage-appliances-2010.svg"))
-          .setMultilineText("supplier", form.getSupplierName())
-          .setMultilineText("model", form.getModelName());
+          "labels/household-refrigerating-appliances/wine-storage-appliances-2010.svg"));
     } else {
       templatePopulator = new TemplatePopulator(templateParserService.parseTemplate(
           "labels/household-refrigerating-appliances/wine-storage-appliances-2021.svg"))
           .setQrCode(form)
-          .setText("supplier", form.getSupplierName())
-          .setText("model", form.getModelName())
           .applyRatingCssClass("noiseClass", RatingClass.valueOf(form.getNoiseEmissionsClass()));
     }
 
     return templatePopulator
+      .setMultilineText("supplier", form.getSupplierName())
+      .setMultilineText("model", form.getModelName())
       .setRatingArrow("rating", RatingClass.valueOf(form.getEfficiencyRating()), legislationCategory.getPrimaryRatingRange())
       .setText("kwhAnnum", form.getAnnualEnergyConsumption())
       .setText("bottleCapacity", form.getBottleCapacity())

--- a/src/main/java/uk/gov/beis/els/categories/refrigeratorsdirectsales/model/BeverageCoolersForm.java
+++ b/src/main/java/uk/gov/beis/els/categories/refrigeratorsdirectsales/model/BeverageCoolersForm.java
@@ -1,15 +1,14 @@
 package uk.gov.beis.els.categories.refrigeratorsdirectsales.model;
 
-import uk.gov.beis.els.categories.common.StandardTemplateForm20Char;
+import javax.validation.constraints.Digits;
+import javax.validation.constraints.NotBlank;
+import javax.validation.groups.Default;
+import uk.gov.beis.els.categories.common.StandardTemplateForm40Char;
 import uk.gov.beis.els.categories.internetlabelling.model.InternetLabellingGroup;
 import uk.gov.beis.els.model.meta.DualModeField;
 import uk.gov.beis.els.model.meta.FieldPrompt;
 
-import javax.validation.constraints.Digits;
-import javax.validation.constraints.NotBlank;
-import javax.validation.groups.Default;
-
-public class BeverageCoolersForm extends StandardTemplateForm20Char {
+public class BeverageCoolersForm extends StandardTemplateForm40Char {
   @FieldPrompt("Energy efficiency class indicator")
   @NotBlank(message = "Select an energy efficiency indicator", groups = {Default.class, InternetLabellingGroup.class})
   @DualModeField

--- a/src/main/java/uk/gov/beis/els/categories/refrigeratorsdirectsales/model/DisplayCabinetsForm.java
+++ b/src/main/java/uk/gov/beis/els/categories/refrigeratorsdirectsales/model/DisplayCabinetsForm.java
@@ -1,18 +1,17 @@
 package uk.gov.beis.els.categories.refrigeratorsdirectsales.model;
 
-import org.hibernate.validator.group.GroupSequenceProvider;
-import uk.gov.beis.els.categories.common.StandardTemplateForm20Char;
-import uk.gov.beis.els.categories.internetlabelling.model.InternetLabellingGroup;
-import uk.gov.beis.els.model.meta.DualModeField;
-import uk.gov.beis.els.model.meta.FieldPrompt;
-
 import javax.validation.constraints.Digits;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.groups.Default;
+import org.hibernate.validator.group.GroupSequenceProvider;
+import uk.gov.beis.els.categories.common.StandardTemplateForm40Char;
+import uk.gov.beis.els.categories.internetlabelling.model.InternetLabellingGroup;
+import uk.gov.beis.els.model.meta.DualModeField;
+import uk.gov.beis.els.model.meta.FieldPrompt;
 
 @GroupSequenceProvider(DisplayCabinetsFormSequenceProvider.class)
-public class DisplayCabinetsForm extends StandardTemplateForm20Char {
+public class DisplayCabinetsForm extends StandardTemplateForm40Char {
   @FieldPrompt("Energy efficiency class indicator")
   @NotBlank(message = "Select an energy efficiency indicator", groups = {Default.class, InternetLabellingGroup.class})
   @DualModeField

--- a/src/main/java/uk/gov/beis/els/categories/refrigeratorsdirectsales/model/IceCreamFreezersForm.java
+++ b/src/main/java/uk/gov/beis/els/categories/refrigeratorsdirectsales/model/IceCreamFreezersForm.java
@@ -1,15 +1,14 @@
 package uk.gov.beis.els.categories.refrigeratorsdirectsales.model;
 
-import uk.gov.beis.els.categories.common.StandardTemplateForm20Char;
+import javax.validation.constraints.Digits;
+import javax.validation.constraints.NotBlank;
+import javax.validation.groups.Default;
+import uk.gov.beis.els.categories.common.StandardTemplateForm40Char;
 import uk.gov.beis.els.categories.internetlabelling.model.InternetLabellingGroup;
 import uk.gov.beis.els.model.meta.DualModeField;
 import uk.gov.beis.els.model.meta.FieldPrompt;
 
-import javax.validation.constraints.Digits;
-import javax.validation.constraints.NotBlank;
-import javax.validation.groups.Default;
-
-public class IceCreamFreezersForm extends StandardTemplateForm20Char {
+public class IceCreamFreezersForm extends StandardTemplateForm40Char {
   @FieldPrompt("Energy efficiency class indicator")
   @NotBlank(message = "Select an energy efficiency indicator", groups = {Default.class, InternetLabellingGroup.class})
   @DualModeField

--- a/src/main/java/uk/gov/beis/els/categories/refrigeratorsdirectsales/model/VendingMachinesForm.java
+++ b/src/main/java/uk/gov/beis/els/categories/refrigeratorsdirectsales/model/VendingMachinesForm.java
@@ -1,18 +1,17 @@
 package uk.gov.beis.els.categories.refrigeratorsdirectsales.model;
 
-import org.hibernate.validator.group.GroupSequenceProvider;
-import uk.gov.beis.els.categories.common.StandardTemplateForm20Char;
-import uk.gov.beis.els.categories.internetlabelling.model.InternetLabellingGroup;
-import uk.gov.beis.els.model.meta.DualModeField;
-import uk.gov.beis.els.model.meta.FieldPrompt;
-
 import javax.validation.constraints.Digits;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.groups.Default;
+import org.hibernate.validator.group.GroupSequenceProvider;
+import uk.gov.beis.els.categories.common.StandardTemplateForm40Char;
+import uk.gov.beis.els.categories.internetlabelling.model.InternetLabellingGroup;
+import uk.gov.beis.els.model.meta.DualModeField;
+import uk.gov.beis.els.model.meta.FieldPrompt;
 
 @GroupSequenceProvider(VendingMachinesFormSequenceProvider.class)
-public class VendingMachinesForm extends StandardTemplateForm20Char {
+public class VendingMachinesForm extends StandardTemplateForm40Char {
   @FieldPrompt("Energy efficiency class indicator")
   @NotBlank(message = "Select an energy efficiency indicator", groups = {Default.class, InternetLabellingGroup.class})
   @DualModeField

--- a/src/main/java/uk/gov/beis/els/categories/refrigeratorsdirectsales/service/RefrigeratorsDirectSalesService.java
+++ b/src/main/java/uk/gov/beis/els/categories/refrigeratorsdirectsales/service/RefrigeratorsDirectSalesService.java
@@ -37,8 +37,8 @@ public class RefrigeratorsDirectSalesService {
     return templatePopulator
         .setQrCode(form)
         .setRatingArrow("rating", RatingClass.valueOf(form.getEfficiencyRating()), legislationCategory.getPrimaryRatingRange())
-        .setText("supplier", form.getSupplierName())
-        .setText("model", form.getModelName())
+        .setMultilineText("supplier", form.getSupplierName())
+        .setMultilineText("model", form.getModelName())
         .setText("kwhAnnum", form.getAnnualEnergyConsumption())
         .setText("capacity", form.getCapacity())
         .setText("compartmentTemp", form.getCompartmentTemp())
@@ -53,8 +53,8 @@ public class RefrigeratorsDirectSalesService {
     return templatePopulator
         .setQrCode(form)
         .setRatingArrow("rating", RatingClass.valueOf(form.getEfficiencyRating()), legislationCategory.getPrimaryRatingRange())
-        .setText("supplier", form.getSupplierName())
-        .setText("model", form.getModelName())
+        .setMultilineText("supplier", form.getSupplierName())
+        .setMultilineText("model", form.getModelName())
         .setText("kwhAnnum", form.getAnnualEnergyConsumption())
         .setText("capacity", form.getCapacity())
         .setText("compartmentTemp", form.getCompartmentTemp())
@@ -75,8 +75,8 @@ public class RefrigeratorsDirectSalesService {
     return templatePopulator
         .setQrCode(form)
         .setRatingArrow("rating", RatingClass.valueOf(form.getEfficiencyRating()), legislationCategory.getPrimaryRatingRange())
-        .setText("supplier", form.getSupplierName())
-        .setText("model", form.getModelName())
+        .setMultilineText("supplier", form.getSupplierName())
+        .setMultilineText("model", form.getModelName())
         .setText("kwhAnnum", form.getAnnualEnergyConsumption())
         .applyCssClassToId("fridgeSection", "hasFridgeSection")
         .setText("fridgeCapacity", form.getFridgeCapacity())
@@ -112,8 +112,8 @@ public class RefrigeratorsDirectSalesService {
     return templatePopulator
         .setQrCode(form)
         .setRatingArrow("rating", RatingClass.valueOf(form.getEfficiencyRating()), legislationCategory.getPrimaryRatingRange())
-        .setText("supplier", form.getSupplierName())
-        .setText("model", form.getModelName())
+        .setMultilineText("supplier", form.getSupplierName())
+        .setMultilineText("model", form.getModelName())
         .setText("kwhAnnum", form.getAnnualEnergyConsumption())
         .setText("fridgeCapacity", form.getFridgeCapacity())
         .applyCssClassToId("fridgeCapacityUnits", "fridgeCapacityUnitsm2")

--- a/src/main/java/uk/gov/beis/els/categories/televisions/service/TelevisionsService.java
+++ b/src/main/java/uk/gov/beis/els/categories/televisions/service/TelevisionsService.java
@@ -51,8 +51,6 @@ public class TelevisionsService {
 
       templatePopulator
           .setRatingArrow("rating", RatingClass.valueOf(form.getEfficiencyRating()), legislationCategory.getPrimaryRatingRange())
-          .setMultilineText("supplier", form.getSupplierName())
-          .setMultilineText("model", form.getModelName())
           .setText("watt", form.getPowerConsumption())
           .setText("kwhAnnum", form.getAnnualEnergyConsumption());
     } else {
@@ -60,8 +58,6 @@ public class TelevisionsService {
           templateParserService.parseTemplate("labels/televisions-electronic-displays/electronic-displays-2021.svg"));
 
       templatePopulator
-          .setText("supplier", form.getSupplierName())
-          .setText("model", form.getModelName())
           .setQrCode(form)
           .setRatingArrow("rating", RatingClass.valueOf(form.getEfficiencyRatingSdr()),
               legislationCategory.getPrimaryRatingRange())
@@ -78,6 +74,8 @@ public class TelevisionsService {
     }
 
     return templatePopulator
+        .setMultilineText("supplier", form.getSupplierName())
+        .setMultilineText("model", form.getModelName())
         .setText("cm", form.getScreenSizeCm())
         .setText("inch", form.getScreenSizeInch())
         .asProcessedEnergyLabel(ProductMetadata.TV, form);

--- a/src/main/java/uk/gov/beis/els/categories/washingmachines/model/WasherDryerForm.java
+++ b/src/main/java/uk/gov/beis/els/categories/washingmachines/model/WasherDryerForm.java
@@ -4,14 +4,14 @@ import javax.validation.constraints.Digits;
 import javax.validation.constraints.NotBlank;
 import javax.validation.groups.Default;
 import org.hibernate.validator.constraints.Range;
-import uk.gov.beis.els.categories.common.StandardTemplateForm20Char;
+import uk.gov.beis.els.categories.common.StandardTemplateForm40Char;
 import uk.gov.beis.els.categories.internetlabelling.model.InternetLabellingGroup;
 import uk.gov.beis.els.model.meta.DualModeField;
 import uk.gov.beis.els.model.meta.FieldPrompt;
 import uk.gov.beis.els.model.meta.StaticProductText;
 
 @StaticProductText("You must attach the label to the front or top of the product so that it’s easy to see. If it's a built-in washer-dryer it doesn't have to be attached to the product, but it must still be easy to see. It must be at least 96mm x 192mm when printed.")
-public class WasherDryerForm extends StandardTemplateForm20Char {
+public class WasherDryerForm extends StandardTemplateForm40Char {
 
   @FieldPrompt("Energy efficiency class for the complete cycle")
   @NotBlank(message = "Select an energy efficiency class for the complete cycle", groups = {Default.class, InternetLabellingGroup.class})

--- a/src/main/java/uk/gov/beis/els/categories/washingmachines/service/WashingMachinesService.java
+++ b/src/main/java/uk/gov/beis/els/categories/washingmachines/service/WashingMachinesService.java
@@ -46,8 +46,6 @@ public class WashingMachinesService {
     if (legislationCategory.equals(LEGISLATION_CATEGORY_PRE_MARCH_2021)) {
       templatePopulator = new TemplatePopulator(templateParserService.parseTemplate("labels/washing-machines/washing-machines-2010.svg"));
       templatePopulator
-          .setMultilineText("supplier", form.getSupplierName())
-          .setMultilineText("model", form.getModelName())
           .setText("kwhAnnum", form.getAnnualEnergyConsumption())
           .setText("lAnnum", form.getAnnualWaterConsumption())
           .setText("kg", form.getCapacity())
@@ -57,8 +55,6 @@ public class WashingMachinesService {
       templatePopulator = new TemplatePopulator(templateParserService.parseTemplate("labels/washing-machines/washing-machines-2021.svg"));
       templatePopulator
           .setQrCode(form)
-          .setText("supplier", form.getSupplierName())
-          .setText("model", form.getModelName())
           .setText("kwh100cycles", form.getEnergyConsumptionPer100Cycles())
           .setText("kg", form.getEcoRatedCapacity())
           .setHoursMinutes("duration", form.getProgrammeDurationHours(), form.getProgrammeDurationMinutes())
@@ -68,6 +64,8 @@ public class WashingMachinesService {
     }
 
     return templatePopulator
+        .setMultilineText("supplier", form.getSupplierName())
+        .setMultilineText("model", form.getModelName())
         .applyRatingCssClass("spinClass", RatingClass.valueOf(form.getSpinDryingEfficiencyRating()))
         .setRatingArrow("rating", RatingClass.valueOf(form.getEfficiencyRating()), legislationCategory.getPrimaryRatingRange())
         .asProcessedEnergyLabel(ProductMetadata.WASHING_MACHINES, form);
@@ -79,8 +77,8 @@ public class WashingMachinesService {
 
     return templatePopulator
         .setQrCode(form)
-        .setText("supplier", form.getSupplierName())
-        .setText("model", form.getModelName())
+        .setMultilineText("supplier", form.getSupplierName())
+        .setMultilineText("model", form.getModelName())
         .setRatingArrow("completeCycleRating", RatingClass.valueOf(form.getCompleteCycleEfficiencyRating()), legislationCategory.getPrimaryRatingRange())
         .setRatingArrow("washCycleRating", RatingClass.valueOf(form.getWashingCycleEfficiencyRating()), legislationCategory.getPrimaryRatingRange())
         .setText("completeCycleKwh100cycles", form.getCompleteCycleEnergyConsumption())

--- a/src/main/resources/labels/dishwashers/dishwashers-2021.svg
+++ b/src/main/resources/labels/dishwashers/dishwashers-2021.svg
@@ -258,7 +258,8 @@
   <g class="cls-12">
     <path class="cls-24" d="M204.0455,303.76581a19.85036,19.85036,0,0,1,19.792,18.854h2.792l-4.136,7.165-4.137-7.165h2.692a17.0213,17.0213,0,1,0-4.809,12.909l1.994,1.951a19.84257,19.84257,0,1,1-14.188-33.714"/>
   </g>
-  <text id="supplier" class="cls-32" transform="translate(8.50391 72.04694)">X</text>
+  <text id="supplierLine1" class="cls-32" transform="translate(8.50391 62.04694)">X</text>
+  <text id="supplierLine2" class="cls-32" transform="translate(8.50391 72.04694)">X</text>
   <g id="rating">
     <polygon id="ratingArrow" points="219.514 82.205 198.351 99.919 219.514 116.221 263.547 116.221 263.547 82.205 219.514 82.205"/>
     <text id="ratingLetter" class="cls-17" transform="translate(231.84473 108.74097) scale(1 1.012)">A</text>
@@ -267,5 +268,6 @@
     <rect class="cls-33" x="223.82323" y="8.50403" width="39.68504" height="39.68504"/>
     <text class="cls-34" transform="translate(227.70317 30.48639)">QR code</text>
   </g>
-  <text id="model" class="cls-30" transform="translate(263.8 71.98981)" text-anchor="end">X</text>
+  <text id="modelLine1" class="cls-30" transform="translate(263.8 61.98981)" text-anchor="end">X</text>
+  <text id="modelLine2" class="cls-30" transform="translate(263.8 71.98981)" text-anchor="end">X</text>
 </svg>

--- a/src/main/resources/labels/household-refrigerating-appliances/household-refrigerating-appliances-2021.svg
+++ b/src/main/resources/labels/household-refrigerating-appliances/household-refrigerating-appliances-2021.svg
@@ -242,6 +242,8 @@
     <tspan class="cls-29" xml:space="preserve"> kWh/annum</tspan>
   </text>
 
-  <text id="supplier" class="cls-30" transform="translate(8.50391 72.04694)">X</text>
-  <text id="model" class="cls-26" transform="translate(263.8 71.98981)" text-anchor="end">X</text>
+  <text id="supplierLine1" class="cls-30" transform="translate(8.50391 62.04694)">X</text>
+  <text id="supplierLine2" class="cls-30" transform="translate(8.50391 72.04694)">X</text>
+  <text id="modelLine1" class="cls-26" transform="translate(263.8 61.98981)" text-anchor="end">X</text>
+  <text id="modelLine2" class="cls-26" transform="translate(263.8 71.98981)" text-anchor="end">X</text>
 </svg>

--- a/src/main/resources/labels/household-refrigerating-appliances/wine-storage-appliances-2021.svg
+++ b/src/main/resources/labels/household-refrigerating-appliances/wine-storage-appliances-2021.svg
@@ -217,6 +217,8 @@
     <tspan class="cls-29" xml:space="preserve"> kWh/annum</tspan>
   </text>
 
-  <text id="supplier" class="cls-30" transform="translate(8.50391 72.04694)">X</text>
-  <text id="model" class="cls-26" transform="translate(263.8 71.98981)" text-anchor="end">X</text>
+  <text id="supplierLine1" class="cls-30" transform="translate(8.50391 62.04694)">X</text>
+  <text id="supplierLine2" class="cls-30" transform="translate(8.50391 72.04694)">X</text>
+  <text id="modelLine1" class="cls-26" transform="translate(263.8 61.98981)" text-anchor="end">X</text>
+  <text id="modelLine2" class="cls-26" transform="translate(263.8 71.98981)" text-anchor="end">X</text>
 </svg>

--- a/src/main/resources/labels/refrigerators-direct-sales/commercial-refrigeration-beverage.svg
+++ b/src/main/resources/labels/refrigerators-direct-sales/commercial-refrigeration-beverage.svg
@@ -180,8 +180,11 @@
   <polygon class="cls-17" points="202.728 14.059 209.186 14.059 206.622 22.221 213.649 21.069 203.583 43.059 206.622 27.118 199.879 27.407 202.728 14.059"/>
   <line class="cls-7" x1="8.504" y1="295.05321" x2="263.547" y2="295.05321"/>
   <line class="cls-7" x1="8.504" y1="351.57112" x2="263.547" y2="351.57112"/>
-  <text id="supplier" class="cls-18" transform="translate(8.50391 72.04694)">X</text>
-  <text id="model" class="cls-19" transform="translate(263.8 71.98981)" text-anchor="end">X</text>
+  <text id="supplierLine1" class="cls-18" transform="translate(8.50391 62.04694)">X</text>
+  <text id="supplierLine2" class="cls-18" transform="translate(8.50391 72.04694)">X</text>
+  <text id="modelLine1" class="cls-19" transform="translate(263.8 61.98981)" text-anchor="end">X</text>
+  <text id="modelLine2" class="cls-19" transform="translate(263.8 71.98981)" text-anchor="end">X</text>
+
   <text class="cls-20" transform="translate(259.0332 502.50778) rotate(90)">2019/2018</text>
   <text transform="translate(73 439.37018)" text-anchor="middle">
     <tspan id="capacity" class="cls-21">X</tspan>

--- a/src/main/resources/labels/refrigerators-direct-sales/ice-cream-freezers.svg
+++ b/src/main/resources/labels/refrigerators-direct-sales/ice-cream-freezers.svg
@@ -180,8 +180,10 @@
   <polygon class="cls-17" points="202.728 14.059 209.186 14.059 206.622 22.221 213.649 21.069 203.583 43.059 206.622 27.118 199.879 27.407 202.728 14.059"/>
   <line class="cls-7" x1="8.504" y1="295.05321" x2="263.547" y2="295.05321"/>
   <line class="cls-7" x1="8.504" y1="351.57112" x2="263.547" y2="351.57112"/>
-  <text id="supplier" class="cls-18" transform="translate(8.50391 72.04694)">X</text>
-  <text id="model" class="cls-19" transform="translate(263.8 71.98981)" text-anchor="end">X</text>
+  <text id="supplierLine1" class="cls-18" transform="translate(8.50391 62.04694)">X</text>
+  <text id="supplierLine2" class="cls-18" transform="translate(8.50391 72.04694)">X</text>
+  <text id="modelLine1" class="cls-19" transform="translate(263.8 61.98981)" text-anchor="end">X</text>
+  <text id="modelLine2" class="cls-19" transform="translate(263.8 71.98981)" text-anchor="end">X</text>
   <text class="cls-20" transform="translate(259.0332 502.50778) rotate(90)">2019/2018</text>
   <text transform="translate(73 439.37018)" text-anchor="middle">
     <tspan id="capacity" class="cls-21">X</tspan>

--- a/src/main/resources/labels/refrigerators-direct-sales/refrigerators-direct-sales.svg
+++ b/src/main/resources/labels/refrigerators-direct-sales/refrigerators-direct-sales.svg
@@ -185,9 +185,10 @@
   <polygon class="cls-14" points="202.728 14.059 209.186 14.059 206.622 22.221 213.649 21.069 203.583 43.059 206.622 27.118 199.879 27.407 202.728 14.059"/>
   <line class="cls-5" x1="8.504" y1="295.05321" x2="263.547" y2="295.05321"/>
   <line class="cls-5" x1="8.504" y1="351.57112" x2="263.547" y2="351.57112"/>
-  <text id="supplier" class="cls-15" transform="translate(8.50391 72.04694)">X</text>
-  <text id="model" class="cls-16" transform="translate(263.8 71.98981)" text-anchor="end">X</text>
-  <text class="cls-17" transform="translate(259.0332 502.50778) rotate(90)">2019/2018</text>
+  <text id="supplierLine1" class="cls-15" transform="translate(8.50391 62.04694)">X</text>
+  <text id="supplierLine2" class="cls-15" transform="translate(8.50391 72.04694)">X</text>
+  <text id="modelLine1" class="cls-16" transform="translate(263.8 61.98981)" text-anchor="end">X</text>
+  <text id="modelLine2" class="cls-16" transform="translate(263.8 71.98981)" text-anchor="end">X</text>  <text class="cls-17" transform="translate(259.0332 502.50778) rotate(90)">2019/2018</text>
   <text transform="translate(136.063005 334.5235)" text-anchor="middle">
     <tspan id="kwhAnnum" class="cls-18">X</tspan>
     <tspan class="cls-20" xml:space="preserve"> kWh/annum</tspan>

--- a/src/main/resources/labels/televisions-electronic-displays/electronic-displays-2021.svg
+++ b/src/main/resources/labels/televisions-electronic-displays/electronic-displays-2021.svg
@@ -238,8 +238,10 @@
     <polygon id="ratingArrow" points="219.514 82.63 198.351 100.344 219.514 116.646 263.547 116.646 263.547 82.63 219.514 82.63"/>
     <text id="ratingLetter" class="cls-29" transform="translate(231.84473 109.16608) scale(1 1.012)">A</text>
   </g>
-  <text id="supplier" class="cls-30" transform="translate(8.59717 72.93561)">X</text>
-  <text id="model" class="cls-19" transform="translate(264.55605 72.93561)" text-anchor="end">X</text>
+  <text id="supplierLine1" class="cls-30" transform="translate(8.59717 62.93561)">X</text>
+  <text id="supplierLine2" class="cls-30" transform="translate(8.59717 72.93561)">X</text>
+  <text id="modelLine1" class="cls-19" transform="translate(263.8 62.93561)" text-anchor="end">X</text>
+  <text id="modelLine2" class="cls-19" transform="translate(263.8 72.93561)" text-anchor="end">X</text>
   <g id="qrCode">
     <rect class="cls-31" x="216.85005" y="8.50397" width="46.77165" height="46.77165"/>
     <text class="cls-19" transform="translate(221.42295 34.41108)">QR code</text>

--- a/src/main/resources/labels/washing-machines/washer-dryers-2021.svg
+++ b/src/main/resources/labels/washing-machines/washer-dryers-2021.svg
@@ -253,8 +253,10 @@
   </g>
   <polygon class="cls-19" points="151.837 446.197 154.553 441.589 149.121 441.589 151.837 446.197"/>
   <path class="cls-15" d="M139.4187,447.05352l-3.862-5.477m0,0v-11.41"/>
-  <text id="supplier" class="cls-20" transform="translate(8.59717 72.28326)">X</text>
-  <text id="model" class="cls-21" transform="translate(263.8 72.28326)" text-anchor="end">X</text>
+  <text id="supplierLine1" class="cls-20" transform="translate(8.59717 62.28326)">X</text>
+  <text id="supplierLine2" class="cls-20" transform="translate(8.59717 72.28326)">X</text>
+  <text id="modelLine1" class="cls-21" transform="translate(263.8 62.28326)" text-anchor="end">X</text>
+  <text id="modelLine2" class="cls-21" transform="translate(263.8 72.28326)" text-anchor="end">X</text>
   <text transform="translate(105 362.73737)" text-anchor="end">
     <tspan id="completeCycleKg" class="cls-22">X</tspan><tspan class="cls-23">kg</tspan>
   </text>

--- a/src/main/resources/labels/washing-machines/washing-machines-2021.svg
+++ b/src/main/resources/labels/washing-machines/washing-machines-2021.svg
@@ -210,8 +210,10 @@
   <polygon class="cls-17" points="202.728 14.059 209.186 14.059 206.622 22.221 213.649 21.069 203.583 43.059 206.622 27.118 199.879 27.407 202.728 14.059"/>
   <line class="cls-7" x1="8.504" y1="295.05321" x2="263.547" y2="295.05321"/>
   <line class="cls-7" x1="8.504" y1="351.57112" x2="263.547" y2="351.57112"/>
-  <text id="supplier" class="cls-18" transform="translate(8.50391 72.04694)">X</text>
-  <text id="model" class="cls-19" transform="translate(263.8 71.98981)" text-anchor="end">X</text>
+  <text id="supplierLine1" class="cls-18" transform="translate(8.50391 62.04694)">X</text>
+  <text id="supplierLine2" class="cls-18" transform="translate(8.50391 72.04694)">X</text>
+  <text id="modelLine1" class="cls-19" transform="translate(263.8 61.98981)" text-anchor="end">X</text>
+  <text id="modelLine2" class="cls-19" transform="translate(263.8 71.98981)" text-anchor="end">X</text>
   <text class="cls-20" transform="translate(259.0332 502.50778) rotate(90)">2019/2014</text>
 
   <text transform="translate(212.65723 439.37018)" text-anchor="middle">


### PR DESCRIPTION
There was enough room in most templates to add a second line, so the rescaled labels can handle the same number of characters as the old labels. The light sources labels have no room for a second line but I've tested with representative 20-character strings and they just about fit. When the old labels are retired for these categories we can bump up the number of allowed characters.