### PR TITLE
Revert change to labelMode model attribute

### DIFF
--- a/src/main/java/uk/gov/beis/els/mvc/FormAnnotationHandlerInterceptor.java
+++ b/src/main/java/uk/gov/beis/els/mvc/FormAnnotationHandlerInterceptor.java
@@ -39,12 +39,12 @@ public class FormAnnotationHandlerInterceptor implements HandlerInterceptor {
                          Object handler,
                          ModelAndView modelAndView) {
     if (modelAndView != null) {
-      addInternetLabelModelObjects(request, modelAndView);
       Object form = modelAndView.getModelMap().get(FORM_MODEL_ATTRIBUTE_NAME);
       if (form != null) {
         modelAndView.addObject("fieldPromptMapping",  getFieldPromptMapping(form));
         getStaticProductText(form).ifPresent(t -> modelAndView.addObject("staticProductText", t));
         modelAndView.addObject("fieldWidthMapping", getFieldWidthMapping(form));
+        addInternetLabelModelObjects(request, modelAndView);
         modelAndView.addObject("hiddenFields", getHiddenFields(form, modelAndView));
         modelAndView.addObject("numericFields", getNumericFields(form));
       }

--- a/src/main/resources/templates/layout.ftl
+++ b/src/main/resources/templates/layout.ftl
@@ -104,7 +104,7 @@
               <@govukErrorSummary.errorSummary errorItems=errorList/>
             </#if>
 
-            <#if labelMode=='INTERNET'>
+            <#if labelMode?has_content && labelMode=='INTERNET'>
               <span class="${captionClass}">
               <#if showRescaledInternetLabelGuidance>
                   Arrow image
@@ -120,7 +120,7 @@
 
               <#if showInsetText>
                 <div class="govuk-inset-text">
-                  <#if labelMode=='INTERNET'>
+                  <#if labelMode?has_content && labelMode=='INTERNET'>
                     <#if showRescaledInternetLabelGuidance>
                       <p>
                         Use this form to download an arrow image of this product’s energy efficiency class. This image should be used:


### PR DESCRIPTION
Other uses of `labelMode` occur with the context of a form so do not need the `has_content` check