### PR TITLE
Remove rescaled labels from Lamps forms

### DIFF
--- a/src/main/java/uk/gov/beis/els/categories/lamps/model/LampsCategory.java
+++ b/src/main/java/uk/gov/beis/els/categories/lamps/model/LampsCategory.java
@@ -15,34 +15,30 @@ public class LampsCategory implements Category {
   public static final Category GET = new LampsCategory();
 
   private static List<CategoryItem> subCategories = new ImmutableList.Builder<CategoryItem>()
-    .add(new CategoryItem(
-        "LAMPS",
-        "An original-style or new-style 'rescaled' label including the energy rating, weighted energy consumption, supplier's name and model identification code",
-        ReverseRouter.route(on(LampsController.class).renderLamps(null))))
-    .add(new CategoryItem(
-        "LAMPS_EX_NAME_MODEL",
-        "An original-style label including the energy rating and weighted energy consumption only",
-        ReverseRouter.route(on(LampsController.class).renderLampsExNameModel(null))))
-    .add(new CategoryItem(
-        "LAMPS_EX_NAME_MODEL_CONSUMPTION",
-        "An original-style label including the energy rating only",
-        ReverseRouter.route(on(LampsController.class).renderLampsExNameModelConsumption(null))))
-    .add(new CategoryItem(
-        "LAMPS_PACKAGING_ARROW",
-        "An arrow containing the energy rating for the front of the packaging, for products which use a new-style 'rescaled' label",
-        ReverseRouter.route(on(LampsController.class).renderLampsPackagingArrow(null))))
-    .build();
+      .add(new CategoryItem(
+          "LAMPS",
+          "The energy rating, weighted energy consumption, the supplier's name and model identification code",
+          ReverseRouter.route(on(LampsController.class).renderLamps(null))))
+      .add(new CategoryItem(
+          "LAMPS_EX_NAME_MODEL",
+          "The energy rating and weighted energy consumption only",
+          ReverseRouter.route(on(LampsController.class).renderLampsExNameModel(null))))
+      .add(new CategoryItem(
+          "LAMPS_EX_NAME_MODEL_CONSUMPTION",
+          "The energy rating only",
+          ReverseRouter.route(on(LampsController.class).renderLampsExNameModelConsumption(null))))
+      .build();
 
   private LampsCategory(){}
 
   @Override
   public String getCategoryQuestionText() {
-    return "What do you need to create?";
+    return "What information should the label include about the lamp?";
   }
 
   @Override
   public String getNoSelectionErrorMessage() {
-    return "Select which type of label you need to create";
+    return "Select the information which should be included on the label";
   }
 
   @Override

--- a/src/main/java/uk/gov/beis/els/categories/lamps/model/LampsForm.java
+++ b/src/main/java/uk/gov/beis/els/categories/lamps/model/LampsForm.java
@@ -12,14 +12,9 @@ import uk.gov.beis.els.model.meta.DualModeField;
 import uk.gov.beis.els.model.meta.FieldPrompt;
 import uk.gov.beis.els.model.meta.StaticProductText;
 
-@StaticProductText("<p>Original-style labels must usually be at least 36mm x 75mm when attached to packaging. You can scale down the label if no side of the packaging is large enough to contain the label, or if the label would cover more than 50% of the surface area of the largest side. You must only scale down the label enough to meet these conditions, and the label must never be less than 14.4mm x 30mm.</p><p>New-style 'rescaled' labels must be at least 36mm x 72mm, or 20mm x 54mm for the small version of the label.</p>")
+@StaticProductText("The label should be at least 36mm x 76mm when attached to packaging. If it doesn’t fit, you can reduce the height by up to 60 percent. It can be full colour or black and white.")
 @GroupSequenceProvider(LampsFormSequenceProvider.class)
 public class LampsForm extends StandardTemplateForm20Char {
-
-  @FieldPrompt("What style of label do you need to create?")
-  @NotBlank(message = "Select the style of label you need to create", groups = {Default.class, InternetLabellingGroup.class})
-  @DualModeField
-  private String applicableLegislation;
 
   @FieldPrompt("Energy efficiency class of the application")
   @NotBlank(message = "Select an energy efficiency class", groups = {Default.class, InternetLabellingGroup.class})
@@ -53,14 +48,6 @@ public class LampsForm extends StandardTemplateForm20Char {
 
   public void setEnergyConsumption(String energyConsumption) {
     this.energyConsumption = energyConsumption;
-  }
-
-  public String getApplicableLegislation() {
-    return applicableLegislation;
-  }
-
-  public void setApplicableLegislation(String applicableLegislation) {
-    this.applicableLegislation = applicableLegislation;
   }
 
   public String getTemplateSize() {

--- a/src/main/java/uk/gov/beis/els/categories/lamps/model/validation/LampsFormSequenceProvider.java
+++ b/src/main/java/uk/gov/beis/els/categories/lamps/model/validation/LampsFormSequenceProvider.java
@@ -4,22 +4,12 @@ import java.util.ArrayList;
 import java.util.List;
 import org.hibernate.validator.spi.group.DefaultGroupSequenceProvider;
 import uk.gov.beis.els.categories.lamps.model.LampsForm;
-import uk.gov.beis.els.categories.common.PostSeptember2021Field;
-import uk.gov.beis.els.categories.common.PreSeptember2021Field;
-import uk.gov.beis.els.categories.lamps.service.LampsService;
 
 public class LampsFormSequenceProvider implements DefaultGroupSequenceProvider<LampsForm> {
   @Override
   public List<Class<?>> getValidationGroups(LampsForm form) {
     List<Class<?>> sequence = new ArrayList<>();
 
-    if (form != null) {
-      if (LampsService.LEGISLATION_CATEGORY_PRE_SEPTEMBER_2021.getId().equals(form.getApplicableLegislation())) {
-        sequence.add(PreSeptember2021Field.class);
-      } else if (LampsService.LEGISLATION_CATEGORY_POST_SEPTEMBER_2021.getId().equals(form.getApplicableLegislation())) {
-        sequence.add(PostSeptember2021Field.class);
-      }
-    }
     sequence.add(LampsForm.class);
     return sequence;
   }

--- a/src/main/java/uk/gov/beis/els/model/ProductCategory.java
+++ b/src/main/java/uk/gov/beis/els/model/ProductCategory.java
@@ -43,7 +43,7 @@ public class ProductCategory implements Category {
           ReverseRouter.route(on(RefrigeratingAppliancesController.class).handleCategoriesSubmit(null, ReverseRouter.emptyBindingResult()))))
       .add(new CategoryItem(
           "LAMPS",
-          "Lamps and light sources",
+          "Lamps",
           ReverseRouter.route(on(LampsController.class).handleCategoriesSubmit(null, ReverseRouter.emptyBindingResult()))))
       .add(new CategoryItem(
           "LOCAL_SPACE_HEATERS",

--- a/src/main/java/uk/gov/beis/els/model/ProductMetadata.java
+++ b/src/main/java/uk/gov/beis/els/model/ProductMetadata.java
@@ -24,7 +24,7 @@ public enum ProductMetadata {
   HRA_FRIDGE_FREEZER("Household refrigerating appliances - Fridges and freezers", "Refrigerating appliances"),
   HRA_WINE_STORAGE("Household refrigerating appliances - Wine storage appliances", "Refrigerating appliances"),
 
-  LAMPS_FULL("Lamps and light sources - Label with supplier's name, identification code, rating and energy consumption", "Lamps and light sources"),
+  LAMPS_FULL("Lamps - Label with supplier's name, identification code, rating and energy consumption", "Lamps"),
   LAMPS_RATING_CONSUMPTION("Lamps - Label with energy rating and weighted energy consumption only", "Lamps"),
   LAMPS_RATING("Lamps - Label with energy rating only", "Lamps"),
   LAMPS_PACKAGING_ARROW("Lamps and light sources - Packaging arrow", "Lamps and light sources"),

--- a/src/main/resources/templates/categories/lamps/lamps.ftl
+++ b/src/main/resources/templates/categories/lamps/lamps.ftl
@@ -1,15 +1,6 @@
 <#include '../../layout.ftl'>
 
-<@common.standardProductForm "Lamps and light sources">
-    <@govukRadios.radioGroup path="form.applicableLegislation" legendSize="h2">
-        <@common.preSeptember2021RadioItem legislationCategories/>
-
-        <@common.postSeptember2021RadioItem legislationCategories>
-            <@govukTextInput.textInput path="form.qrCodeUrl"/>
-            <@govukRadios.radio path="form.templateSize" radioItems=templateSize legendSize="h2"/>
-            <@govukRadios.radio path="form.templateColour" radioItems=templateColour legendSize="h2"/>
-        </@common.postSeptember2021RadioItem>
-    </@govukRadios.radioGroup>
+<@common.standardProductForm "Lamps">
   <@govukSelect.select path="form.efficiencyRating" options=efficiencyRating/>
   <@govukTextInput.textInput path="form.energyConsumption"/>
 </@common.standardProductForm>


### PR DESCRIPTION
Removed the option to create rescaled Light Sources labels until it's confirmed that these will be introduced in the UK. These are the minimum changes to get the forms looking how they did before - templates etc are still there, hopefully we'll be able to just revert this change to when we need the form changes again.