### PR TITLE
Update govuk-frontend to 3.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2226,9 +2226,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.4.0.tgz",
-      "integrity": "sha512-rmYPtcCtWgz92QBejYwOnfSxbPGYfvSruLwB4CBk/yJtySHRY0whG1e2/iFRRSj0pMx1Bu+zh/IqCTo+84hbFw=="
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.10.0.tgz",
+      "integrity": "sha512-bMc487VcYUPc2XvOrVtGoW3wtmITUoDOd183KMIHVIknWl7wjnOh7uxTVYu4o89UmxgoQuFDDbHhrK0RL3o8gg=="
     },
     "graceful-fs": {
       "version": "4.1.15",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
     "gulp-sourcemaps": "^2.6.5"
   },
   "dependencies": {
-    "govuk-frontend": "^3.4.0"
+    "govuk-frontend": "^3.10.0"
   }
 }

--- a/src/main/resources/templates/govuk/button.ftl
+++ b/src/main/resources/templates/govuk/button.ftl
@@ -4,7 +4,7 @@
   <#if buttonElement="link">
     <a href="${buttonUrl}" class="govuk-button ${buttonClass}">${buttonText}</a>
     <#else>
-    <button type="submit" class="govuk-button<#if disabled>govuk-button--disabled</#if> ${buttonClass}" <#if disabled>disabled="disabled" aria-disabled="true"</#if> value="${buttonText}" name="${buttonText}">
+    <button type="submit" class="govuk-button<#if disabled>govuk-button--disabled</#if> ${buttonClass}" <#if disabled>disabled="disabled" aria-disabled="true"</#if> value="${buttonText}" name="${buttonText}" data-prevent-double-click="true" data-module="govuk-button">
       ${buttonText}
     </button>
   </#if>


### PR DESCRIPTION
Non-breaking release so no changes were needed in the app

Visible changes are minimal - I think limited to the secondary text grey being slightly darker and the border on error inputs being the same size as normal inputs

Before:
![image](https://user-images.githubusercontent.com/1935173/99955828-e5d3f500-2d7c-11eb-9c1f-711f755f4cf9.png)

After:
![image](https://user-images.githubusercontent.com/1935173/99955808-dbb1f680-2d7c-11eb-9fc6-af8791775c44.png)

