### PR TITLE
Feature/march 2021 guidance updates

### DIFF
--- a/src/main/java/uk/gov/beis/els/categories/airconditioners/model/CoolingDuctedAirConditionersForm.java
+++ b/src/main/java/uk/gov/beis/els/categories/airconditioners/model/CoolingDuctedAirConditionersForm.java
@@ -24,7 +24,7 @@ public class CoolingDuctedAirConditionersForm extends StandardTemplateForm50Char
   @Digits(integer = 1, fraction = 1, message = "Enter the EER rated value, 1 digit with an optional decimal place")
   private String eerRated;
 
-  @FieldPrompt("Hourly energy consumption in kWh per 60 minutes")
+  @FieldPrompt("Hourly energy consumption in kWh per 60 minutes, rounded up to the nearest integer")
   @Digits(integer = 2, fraction = 0, message = "Enter the hourly energy consumption, up to 2 digits long")
   private String coolingHourlyEnergyConsumption;
 

--- a/src/main/java/uk/gov/beis/els/categories/airconditioners/model/HeatingDuctedAirConditionersForm.java
+++ b/src/main/java/uk/gov/beis/els/categories/airconditioners/model/HeatingDuctedAirConditionersForm.java
@@ -24,7 +24,7 @@ public class HeatingDuctedAirConditionersForm extends StandardTemplateForm50Char
   @Digits(integer = 1, fraction = 1, message = "Enter the COPrated value, 1 digit with an optional decimal place")
   private String copRated;
 
-  @FieldPrompt("Hourly energy consumption in kWh per 60 minutes")
+  @FieldPrompt("Hourly energy consumption in kWh per 60 minutes, rounded up to the nearest integer")
   @Digits(integer = 2, fraction = 0, message = "Enter the hourly energy consumption, up to 2 digits long")
   private String heatingHourlyEnergyConsumption;
 

--- a/src/main/java/uk/gov/beis/els/categories/airconditioners/model/ReversibleDuctedAirConditionersForm.java
+++ b/src/main/java/uk/gov/beis/els/categories/airconditioners/model/ReversibleDuctedAirConditionersForm.java
@@ -24,8 +24,8 @@ public class ReversibleDuctedAirConditionersForm extends StandardTemplateForm50C
   @Digits(integer = 1, fraction = 1, message = "Enter the EER rated value, 1 digit with an optional decimal place")
   private String eerRated;
 
-  @FieldPrompt("Hourly energy consumption in kWh per 60 minutes")
-  @Digits(integer = 2, fraction = 0, message = "Enter the hourly energy consumption, up to 2 digits long")
+  @FieldPrompt("Hourly energy consumption for cooling in kWh per 60 minutes, rounded up to the nearest integer")
+  @Digits(integer = 2, fraction = 0, message = "Enter the hourly energy consumption for cooling, up to 2 digits long")
   private String coolingHourlyEnergyConsumption;
 
   @FieldPrompt("Energy efficiency class for heating")
@@ -40,8 +40,8 @@ public class ReversibleDuctedAirConditionersForm extends StandardTemplateForm50C
   @Digits(integer = 1, fraction = 1, message = "Enter the COPrated value, 1 digit with an optional decimal place")
   private String copRated;
 
-  @FieldPrompt("Hourly energy consumption in kWh per 60 minutes")
-  @Digits(integer = 2, fraction = 0, message = "Enter the hourly energy consumption, up to 2 digits long")
+  @FieldPrompt("Hourly energy consumption for heating in kWh per 60 minutes, rounded up to the nearest integer")
+  @Digits(integer = 2, fraction = 0, message = "Enter the hourly energy consumption for heating, up to 2 digits long")
   private String heatingHourlyEnergyConsumption;
 
   @FieldPrompt("Sound power levels for indoor units expressed in dB(A) re 1 pW, rounded to the nearest integer")

--- a/src/main/java/uk/gov/beis/els/categories/dishwashers/model/DishwashersForm.java
+++ b/src/main/java/uk/gov/beis/els/categories/dishwashers/model/DishwashersForm.java
@@ -18,8 +18,8 @@ import uk.gov.beis.els.model.meta.StaticProductText;
 @GroupSequenceProvider(DishwashersFormSequenceProvider.class)
 public class DishwashersForm extends StandardTemplateForm30Char {
 
-  @FieldPrompt("What style of label do you need to create?")
-  @NotBlank(message = "Select the style of label you need to create", groups = {Default.class, InternetLabellingGroup.class})
+  @FieldPrompt("What kind of label do you need to create?")
+  @NotBlank(message = "Select the kind of label you need to create", groups = {Default.class, InternetLabellingGroup.class})
   @DualModeField
   private String applicableLegislation;
 

--- a/src/main/java/uk/gov/beis/els/categories/refrigeratingappliances/model/FridgesFreezersForm.java
+++ b/src/main/java/uk/gov/beis/els/categories/refrigeratingappliances/model/FridgesFreezersForm.java
@@ -15,8 +15,8 @@ import uk.gov.beis.els.model.meta.FieldPrompt;
 @GroupSequenceProvider(FridgesFreezersFormSequenceProvider.class)
 public class FridgesFreezersForm extends StandardTemplateForm30Char {
 
-  @FieldPrompt("What style of label do you need to create?")
-  @NotBlank(message = "Select the style of label you need to create", groups = {Default.class, InternetLabellingGroup.class})
+  @FieldPrompt("What kind of label do you need to create?")
+  @NotBlank(message = "Select the kind of label you need to create", groups = {Default.class, InternetLabellingGroup.class})
   @DualModeField
   private String applicableLegislation;
 

--- a/src/main/java/uk/gov/beis/els/categories/refrigeratingappliances/model/WineStorageAppliancesForm.java
+++ b/src/main/java/uk/gov/beis/els/categories/refrigeratingappliances/model/WineStorageAppliancesForm.java
@@ -13,8 +13,8 @@ import uk.gov.beis.els.model.meta.FieldPrompt;
 @GroupSequenceProvider(WineStorageAppliancesFormSequenceProvider.class)
 public class WineStorageAppliancesForm extends StandardTemplateForm30Char {
 
-  @FieldPrompt("What style of label do you need to create?")
-  @NotBlank(message = "Select the style of label you need to create", groups = {Default.class, InternetLabellingGroup.class})
+  @FieldPrompt("What kind of label do you need to create?")
+  @NotBlank(message = "Select the kind of label you need to create", groups = {Default.class, InternetLabellingGroup.class})
   @DualModeField
   private String applicableLegislation;
 

--- a/src/main/java/uk/gov/beis/els/categories/refrigeratorsdirectsales/model/DisplayCabinetsForm.java
+++ b/src/main/java/uk/gov/beis/els/categories/refrigeratorsdirectsales/model/DisplayCabinetsForm.java
@@ -18,7 +18,7 @@ public class DisplayCabinetsForm extends StandardTemplateForm40Char {
   private String efficiencyRating;
 
   @FieldPrompt("The annual electricity consumption in kWh in terms of final energy consumption per year")
-  @Digits(integer = 4, fraction = 0, message = "Enter the annual energy consumption, up to 4 digits long")
+  @Digits(integer = 5, fraction = 0, message = "Enter the annual energy consumption, up to 5 digits long")
   private String annualEnergyConsumption;
 
   @FieldPrompt("Does this model have any display areas functioning at chilled operating temperature?")

--- a/src/main/java/uk/gov/beis/els/categories/televisions/model/TelevisionsForm.java
+++ b/src/main/java/uk/gov/beis/els/categories/televisions/model/TelevisionsForm.java
@@ -57,7 +57,7 @@ public class TelevisionsForm extends StandardTemplateForm30Char {
   private String efficiencyRatingSdr;
 
   @FieldPrompt("On-mode energy consumption in kWh per 1000 hours, when playing SDR content")
-  @Digits(integer = 3, fraction = 0, message = "Enter the energy consumption when playing SDR content, up to 3 digits long", groups = PostMarch2021Field.class)
+  @Digits(integer = 4, fraction = 0, message = "Enter the energy consumption when playing SDR content, up to 4 digits long", groups = PostMarch2021Field.class)
   private String energyConsumptionSdr1000h;
 
   @FieldPrompt("Can this product display HDR content?")
@@ -69,7 +69,7 @@ public class TelevisionsForm extends StandardTemplateForm30Char {
   private String efficiencyRatingHdr;
 
   @FieldPrompt("On-mode energy consumption in kWh per 1000 hours, when playing HDR content")
-  @Digits(integer = 3, fraction = 0, message = "Enter the energy consumption when playing HDR content, up to 3 digits long", groups = HdrGroup.class)
+  @Digits(integer = 4, fraction = 0, message = "Enter the energy consumption when playing HDR content, up to 4 digits long", groups = HdrGroup.class)
   private String energyConsumptionHdr1000h;
 
   @FieldPrompt("Horizontal resolution in pixels")

--- a/src/main/java/uk/gov/beis/els/categories/televisions/model/TelevisionsForm.java
+++ b/src/main/java/uk/gov/beis/els/categories/televisions/model/TelevisionsForm.java
@@ -19,8 +19,8 @@ import uk.gov.beis.els.model.meta.StaticProductText;
 @GroupSequenceProvider(TelevisionsFormSequenceProvider.class)
 public class TelevisionsForm extends StandardTemplateForm30Char {
 
-  @FieldPrompt("What style of label do you need to create?")
-  @NotBlank(message = "Select the style of label you need to create", groups = {Default.class, InternetLabellingGroup.class})
+  @FieldPrompt("What kind of label do you need to create?")
+  @NotBlank(message = "Select the kind of label you need to create", groups = {Default.class, InternetLabellingGroup.class})
   @DualModeField
   private String applicableLegislation;
 

--- a/src/main/java/uk/gov/beis/els/categories/washingmachines/model/WashingMachinesForm.java
+++ b/src/main/java/uk/gov/beis/els/categories/washingmachines/model/WashingMachinesForm.java
@@ -18,8 +18,8 @@ import uk.gov.beis.els.model.meta.StaticProductText;
 @GroupSequenceProvider(WashingMachineFormSequenceProvider.class)
 public class WashingMachinesForm extends StandardTemplateForm30Char {
 
-  @FieldPrompt("What style of label do you need to create?")
-  @NotBlank(message = "Select the style of label you need to create", groups = {Default.class, InternetLabellingGroup.class})
+  @FieldPrompt("What kind of label do you need to create?")
+  @NotBlank(message = "Select the kind of label you need to create", groups = {Default.class, InternetLabellingGroup.class})
   @DualModeField
   private String applicableLegislation;
 

--- a/src/main/java/uk/gov/beis/els/model/SelectableLegislationCategory.java
+++ b/src/main/java/uk/gov/beis/els/model/SelectableLegislationCategory.java
@@ -23,19 +23,19 @@ public class SelectableLegislationCategory extends LegislationCategory {
   }
 
   public static SelectableLegislationCategory preMarch2021(RatingClassRange primaryRatingRange) {
-    return new SelectableLegislationCategory("PRE_MAR2021", "An original-style label for display before 1 March 2021", primaryRatingRange, null);
+    return new SelectableLegislationCategory("PRE_MAR2021", "An old-style energy label", primaryRatingRange, null);
   }
 
   public static SelectableLegislationCategory preMarch2021(RatingClassRange primaryRatingRange, RatingClassRange secondaryRatingRange) {
-    return new SelectableLegislationCategory("PRE_MAR2021", "An original-style label for display before 1 March 2021", primaryRatingRange, secondaryRatingRange);
+    return new SelectableLegislationCategory("PRE_MAR2021", "An old-style energy label", primaryRatingRange, secondaryRatingRange);
   }
 
   public static SelectableLegislationCategory postMarch2021() {
-    return new SelectableLegislationCategory("POST_MAR2021", "A new-style 'rescaled' label for display after 1 March 2021", RatingClassRange.of(RatingClass.A, RatingClass.G), null, InternetLabelTemplate.RESCALED);
+    return new SelectableLegislationCategory("POST_MAR2021", "A new-style rescaled energy label", RatingClassRange.of(RatingClass.A, RatingClass.G), null, InternetLabelTemplate.RESCALED);
   }
 
   public static SelectableLegislationCategory postMarch2021(RatingClassRange secondaryRatingRange) {
-    return new SelectableLegislationCategory("POST_MAR2021", "A new-style 'rescaled' label for display after 1 March 2021", RatingClassRange.of(RatingClass.A, RatingClass.G), secondaryRatingRange, InternetLabelTemplate.RESCALED);
+    return new SelectableLegislationCategory("POST_MAR2021", "A new-style rescaled energy label", RatingClassRange.of(RatingClass.A, RatingClass.G), secondaryRatingRange, InternetLabelTemplate.RESCALED);
   }
 
   public static SelectableLegislationCategory preSeptember2021(RatingClassRange primaryRatingRange) {

--- a/src/main/resources/templates/categories/dishwashers/dishwashers.ftl
+++ b/src/main/resources/templates/categories/dishwashers/dishwashers.ftl
@@ -1,16 +1,7 @@
 <#include '../../layout.ftl'>
 
 <@common.standardProductForm "Dishwashers">
-
-  <#assign radioGroupClass>
-    <#if labelMode=='ENERGY'>
-      govuk-!-margin-bottom-0
-    <#else>
-      govuk-!-margin-bottom-2
-    </#if>
-  </#assign>
-
-  <@govukRadios.radioGroup path="form.applicableLegislation" legendSize="h2" formGroupClass=radioGroupClass>
+  <@govukRadios.radioGroup path="form.applicableLegislation" legendSize="h2" isAboveDetailsComponent=true lastItemHasHiddenContent=(labelMode=='ENERGY')>
     <@common.postMarch2021RadioItem legislationCategories>
         <@govukTextInput.textInput path="form.qrCodeUrl"/>
         <@govukSelect.select path="form.noiseEmissionsClass" options=noiseEmissionsRating/>

--- a/src/main/resources/templates/categories/dishwashers/dishwashers.ftl
+++ b/src/main/resources/templates/categories/dishwashers/dishwashers.ftl
@@ -1,30 +1,41 @@
 <#include '../../layout.ftl'>
 
 <@common.standardProductForm "Dishwashers">
-  <@govukRadios.radioGroup path="form.applicableLegislation" legendSize="h2">
+
+  <#assign radioGroupClass>
+    <#if labelMode=='ENERGY'>
+      govuk-!-margin-bottom-0
+    <#else>
+      govuk-!-margin-bottom-2
+    </#if>
+  </#assign>
+
+  <@govukRadios.radioGroup path="form.applicableLegislation" legendSize="h2" formGroupClass=radioGroupClass>
+    <@common.postMarch2021RadioItem legislationCategories>
+        <@govukTextInput.textInput path="form.qrCodeUrl"/>
+        <@govukSelect.select path="form.noiseEmissionsClass" options=noiseEmissionsRating/>
+        <@govukTextInput.textInput path="form.ecoCapacity"/>
+        <@govukTextInput.textInput path="form.energyConsumptionPer100Cycles"/>
+        <@govukTextInput.textInput path="form.waterConsumptionPerCycle"/>
+        <#if labelMode=='ENERGY'>
+          <div class="govuk-form-group">
+              <@govukFieldset.fieldset legendHeading="Eco programme duration" legendHeadingClass="govuk-fieldset__legend--s" legendSize="h3">
+                  <@govukTextInput.textInput path="form.programmeDurationHours"/>
+                  <@govukTextInput.textInput path="form.programmeDurationMinutes"/>
+              </@govukFieldset.fieldset>
+          </div>
+        </#if>
+    </@common.postMarch2021RadioItem>
+
     <@common.preMarch2021RadioItem legislationCategories>
       <@govukTextInput.textInput path="form.standardCapacity"/>
       <@govukTextInput.textInput path="form.annualEnergyConsumption"/>
       <@govukTextInput.textInput path="form.annualWaterConsumption"/>
       <@govukSelect.select path="form.dryingEfficiencyRating" options=dryingEfficiencyRating/>
     </@common.preMarch2021RadioItem>
-
-    <@common.postMarch2021RadioItem legislationCategories>
-      <@govukTextInput.textInput path="form.qrCodeUrl"/>
-      <@govukSelect.select path="form.noiseEmissionsClass" options=noiseEmissionsRating/>
-      <@govukTextInput.textInput path="form.ecoCapacity"/>
-      <@govukTextInput.textInput path="form.energyConsumptionPer100Cycles"/>
-      <@govukTextInput.textInput path="form.waterConsumptionPerCycle"/>
-      <#if labelMode=='ENERGY'>
-        <div class="govuk-form-group">
-          <@govukFieldset.fieldset legendHeading="Eco programme duration" legendHeadingClass="govuk-fieldset__legend--s" legendSize="h3">
-            <@govukTextInput.textInput path="form.programmeDurationHours"/>
-            <@govukTextInput.textInput path="form.programmeDurationMinutes"/>
-          </@govukFieldset.fieldset>
-        </div>
-      </#if>
-    </@common.postMarch2021RadioItem>
   </@govukRadios.radioGroup>
+
+  <@common.labelTypeGuidanceMarch2021/>
 
   <@govukSelect.select path="form.efficiencyRating" options=efficiencyRating/>
   <@govukTextInput.textInput path="form.noiseEmissions"/>

--- a/src/main/resources/templates/categories/household-refrigerating-appliances/fridgesFreezers.ftl
+++ b/src/main/resources/templates/categories/household-refrigerating-appliances/fridgesFreezers.ftl
@@ -1,7 +1,32 @@
 <#include '../../layout.ftl'>
 
 <@common.standardProductForm "Household fridges and freezers">
-  <@govukRadios.radioGroup path="form.applicableLegislation" legendSize="h2">
+
+  <#assign radioGroupClass>
+    <#if labelMode=='ENERGY'>
+      govuk-!-margin-bottom-0
+    <#else>
+      govuk-!-margin-bottom-2
+    </#if>
+  </#assign>
+
+  <@govukRadios.radioGroup path="form.applicableLegislation" legendSize="h2" formGroupClass=radioGroupClass>
+    <@common.postMarch2021RadioItem legislationCategories>
+
+        <@govukTextInput.textInput path="form.qrCodeUrl"/>
+
+        <@govukRadios.radioYesNo path="form.nonRatedCompartmentPostMarch2021" inline=false hiddenQuestionsWithYesSelected=true>
+            <@govukTextInput.textInput path="form.nonRatedVolumePostMarch2021"/>
+        </@govukRadios.radioYesNo>
+
+        <@govukRadios.radioYesNo path="form.ratedCompartmentPostMarch2021" inline=false hiddenQuestionsWithYesSelected=true>
+            <@govukTextInput.textInput path="form.ratedVolumePostMarch2021"/>
+        </@govukRadios.radioYesNo>
+
+        <@govukSelect.select path="form.noiseEmissionsClass" options=noiseEmissionsRating/>
+
+    </@common.postMarch2021RadioItem>
+
     <@common.preMarch2021RadioItem legislationCategories>
 
       <@govukRadios.radioYesNo path="form.nonRatedCompartmentPreMarch2021" inline=false hiddenQuestionsWithYesSelected=true>
@@ -15,22 +40,10 @@
 
     </@common.preMarch2021RadioItem>
 
-    <@common.postMarch2021RadioItem legislationCategories>
-
-      <@govukTextInput.textInput path="form.qrCodeUrl"/>
-
-      <@govukRadios.radioYesNo path="form.nonRatedCompartmentPostMarch2021" inline=false hiddenQuestionsWithYesSelected=true>
-        <@govukTextInput.textInput path="form.nonRatedVolumePostMarch2021"/>
-      </@govukRadios.radioYesNo>
-
-      <@govukRadios.radioYesNo path="form.ratedCompartmentPostMarch2021" inline=false hiddenQuestionsWithYesSelected=true>
-        <@govukTextInput.textInput path="form.ratedVolumePostMarch2021"/>
-      </@govukRadios.radioYesNo>
-
-      <@govukSelect.select path="form.noiseEmissionsClass" options=noiseEmissionsRating/>
-
-    </@common.postMarch2021RadioItem>
   </@govukRadios.radioGroup>
+
+  <@common.labelTypeGuidanceMarch2021/>
+
   <@govukSelect.select path="form.efficiencyRating" options=efficiencyRating/>
   <@govukTextInput.textInput path="form.annualEnergyConsumption"/>
 

--- a/src/main/resources/templates/categories/household-refrigerating-appliances/fridgesFreezers.ftl
+++ b/src/main/resources/templates/categories/household-refrigerating-appliances/fridgesFreezers.ftl
@@ -1,16 +1,7 @@
 <#include '../../layout.ftl'>
 
 <@common.standardProductForm "Household fridges and freezers">
-
-  <#assign radioGroupClass>
-    <#if labelMode=='ENERGY'>
-      govuk-!-margin-bottom-0
-    <#else>
-      govuk-!-margin-bottom-2
-    </#if>
-  </#assign>
-
-  <@govukRadios.radioGroup path="form.applicableLegislation" legendSize="h2" formGroupClass=radioGroupClass>
+  <@govukRadios.radioGroup path="form.applicableLegislation" legendSize="h2" isAboveDetailsComponent=true lastItemHasHiddenContent=(labelMode=='ENERGY')>
     <@common.postMarch2021RadioItem legislationCategories>
 
         <@govukTextInput.textInput path="form.qrCodeUrl"/>

--- a/src/main/resources/templates/categories/household-refrigerating-appliances/wineStorageAppliances.ftl
+++ b/src/main/resources/templates/categories/household-refrigerating-appliances/wineStorageAppliances.ftl
@@ -1,7 +1,7 @@
 <#include '../../layout.ftl'>
 
 <@common.standardProductForm "Wine storage appliances">
-  <@govukRadios.radioGroup path="form.applicableLegislation" legendSize="h2" formGroupClass="govuk-!-margin-bottom-2">
+  <@govukRadios.radioGroup path="form.applicableLegislation" legendSize="h2" isAboveDetailsComponent=true>
     <@common.postMarch2021RadioItem legislationCategories>
         <@govukTextInput.textInput path="form.qrCodeUrl"/>
         <@govukSelect.select path="form.noiseEmissionsClass" options=noiseEmissionsRating/>

--- a/src/main/resources/templates/categories/household-refrigerating-appliances/wineStorageAppliances.ftl
+++ b/src/main/resources/templates/categories/household-refrigerating-appliances/wineStorageAppliances.ftl
@@ -1,14 +1,17 @@
 <#include '../../layout.ftl'>
 
 <@common.standardProductForm "Wine storage appliances">
-  <@govukRadios.radioGroup path="form.applicableLegislation" legendSize="h2">
-    <@common.preMarch2021RadioItem legislationCategories/>
-
+  <@govukRadios.radioGroup path="form.applicableLegislation" legendSize="h2" formGroupClass="govuk-!-margin-bottom-2">
     <@common.postMarch2021RadioItem legislationCategories>
-      <@govukTextInput.textInput path="form.qrCodeUrl"/>
-      <@govukSelect.select path="form.noiseEmissionsClass" options=noiseEmissionsRating/>
+        <@govukTextInput.textInput path="form.qrCodeUrl"/>
+        <@govukSelect.select path="form.noiseEmissionsClass" options=noiseEmissionsRating/>
     </@common.postMarch2021RadioItem>
+
+    <@common.preMarch2021RadioItem legislationCategories/>
   </@govukRadios.radioGroup>
+
+  <@common.labelTypeGuidanceMarch2021/>
+
   <@govukSelect.select path="form.efficiencyRating" options=efficiencyRating/>
   <@govukTextInput.textInput path="form.annualEnergyConsumption"/>
   <@govukTextInput.textInput path="form.bottleCapacity"/>

--- a/src/main/resources/templates/categories/televisions/televisions.ftl
+++ b/src/main/resources/templates/categories/televisions/televisions.ftl
@@ -2,26 +2,28 @@
 
 <@common.standardProductForm "Televisions and electronic displays">
 
-  <@govukRadios.radioGroup path="form.applicableLegislation" legendSize="h2">
+  <@govukRadios.radioGroup path="form.applicableLegislation" legendSize="h2" formGroupClass="govuk-!-margin-bottom-0">
+    <@common.postMarch2021RadioItem legislationCategories>
+        <@govukTextInput.textInput path="form.qrCodeUrl"/>
+        <@govukSelect.select path="form.efficiencyRatingSdr" options=efficiencyRatingSdr/>
+        <@govukTextInput.textInput path="form.energyConsumptionSdr1000h"/>
+        <@govukRadios.radioYesNo path="form.isHdr" inline=false hiddenQuestionsWithYesSelected=true>
+            <@govukSelect.select path="form.efficiencyRatingHdr" options=efficiencyRatingHdr/>
+            <@govukTextInput.textInput path="form.energyConsumptionHdr1000h"/>
+        </@govukRadios.radioYesNo>
+        <@govukTextInput.textInput path="form.horizontalPixels"/>
+        <@govukTextInput.textInput path="form.verticalPixels"/>
+    </@common.postMarch2021RadioItem>
+
     <@common.preMarch2021RadioItem legislationCategories>
       <@govukSelect.select path="form.efficiencyRating" options=efficiencyRating/>
       <@govukRadios.radioYesNo path="form.powerSwitch"/>
       <@govukTextInput.textInput path="form.powerConsumption"/>
       <@govukTextInput.textInput path="form.annualEnergyConsumption"/>
     </@common.preMarch2021RadioItem>
-
-    <@common.postMarch2021RadioItem legislationCategories>
-      <@govukTextInput.textInput path="form.qrCodeUrl"/>
-      <@govukSelect.select path="form.efficiencyRatingSdr" options=efficiencyRatingSdr/>
-      <@govukTextInput.textInput path="form.energyConsumptionSdr1000h"/>
-      <@govukRadios.radioYesNo path="form.isHdr" inline=false hiddenQuestionsWithYesSelected=true>
-        <@govukSelect.select path="form.efficiencyRatingHdr" options=efficiencyRatingHdr/>
-        <@govukTextInput.textInput path="form.energyConsumptionHdr1000h"/>
-      </@govukRadios.radioYesNo>
-      <@govukTextInput.textInput path="form.horizontalPixels"/>
-      <@govukTextInput.textInput path="form.verticalPixels"/>
-    </@common.postMarch2021RadioItem>
   </@govukRadios.radioGroup>
+
+  <@common.labelTypeGuidanceMarch2021/>
 
   <@govukTextInput.textInput path="form.screenSizeCm"/>
   <@govukTextInput.textInput path="form.screenSizeInch"/>

--- a/src/main/resources/templates/categories/televisions/televisions.ftl
+++ b/src/main/resources/templates/categories/televisions/televisions.ftl
@@ -1,8 +1,7 @@
 <#include '../../layout.ftl'>
 
 <@common.standardProductForm "Televisions and electronic displays">
-
-  <@govukRadios.radioGroup path="form.applicableLegislation" legendSize="h2" formGroupClass="govuk-!-margin-bottom-0">
+  <@govukRadios.radioGroup path="form.applicableLegislation" legendSize="h2" isAboveDetailsComponent=true lastItemHasHiddenContent=true>
     <@common.postMarch2021RadioItem legislationCategories>
         <@govukTextInput.textInput path="form.qrCodeUrl"/>
         <@govukSelect.select path="form.efficiencyRatingSdr" options=efficiencyRatingSdr/>

--- a/src/main/resources/templates/categories/washing-machines/washingMachines.ftl
+++ b/src/main/resources/templates/categories/washing-machines/washingMachines.ftl
@@ -2,14 +2,15 @@
 
 <@common.standardProductForm "Washing machines">
 
-  <@govukRadios.radioGroup path="form.applicableLegislation" legendSize="h2">
-    <@common.preMarch2021RadioItem legislationCategories>
-      <@govukTextInput.textInput path="form.annualEnergyConsumption"/>
-      <@govukTextInput.textInput path="form.annualWaterConsumption"/>
-      <@govukTextInput.textInput path="form.capacity"/>
-      <@govukTextInput.textInput path="form.washingNoiseEmissions"/>
-      <@govukTextInput.textInput path="form.spinningNoiseEmissions"/>
-    </@common.preMarch2021RadioItem>
+  <#assign radioGroupClass>
+    <#if labelMode=='ENERGY'>
+      govuk-!-margin-bottom-0
+    <#else>
+      govuk-!-margin-bottom-2
+    </#if>
+  </#assign>
+
+  <@govukRadios.radioGroup path="form.applicableLegislation" legendSize="h2" formGroupClass=radioGroupClass>
 
     <@common.postMarch2021RadioItem legislationCategories>
       <@govukTextInput.textInput path="form.qrCodeUrl"/>
@@ -28,7 +29,16 @@
         <@govukTextInput.textInput path="form.noiseEmissionValue"/>
 
     </@common.postMarch2021RadioItem>
+
+    <@common.preMarch2021RadioItem legislationCategories>
+        <@govukTextInput.textInput path="form.annualEnergyConsumption"/>
+        <@govukTextInput.textInput path="form.annualWaterConsumption"/>
+        <@govukTextInput.textInput path="form.capacity"/>
+        <@govukTextInput.textInput path="form.washingNoiseEmissions"/>
+        <@govukTextInput.textInput path="form.spinningNoiseEmissions"/>
+    </@common.preMarch2021RadioItem>
   </@govukRadios.radioGroup>
+  <@common.labelTypeGuidanceMarch2021/>
 
   <@govukSelect.select path="form.efficiencyRating" options=efficiencyRating/>
   <@govukSelect.select path="form.spinDryingEfficiencyRating" options=spinDryingEfficiencyRating/>

--- a/src/main/resources/templates/categories/washing-machines/washingMachines.ftl
+++ b/src/main/resources/templates/categories/washing-machines/washingMachines.ftl
@@ -1,16 +1,7 @@
 <#include '../../layout.ftl'>
 
 <@common.standardProductForm "Washing machines">
-
-  <#assign radioGroupClass>
-    <#if labelMode=='ENERGY'>
-      govuk-!-margin-bottom-0
-    <#else>
-      govuk-!-margin-bottom-2
-    </#if>
-  </#assign>
-
-  <@govukRadios.radioGroup path="form.applicableLegislation" legendSize="h2" formGroupClass=radioGroupClass>
+  <@govukRadios.radioGroup path="form.applicableLegislation" legendSize="h2" isAboveDetailsComponent=true lastItemHasHiddenContent=(labelMode=='ENERGY')>
 
     <@common.postMarch2021RadioItem legislationCategories>
       <@govukTextInput.textInput path="form.qrCodeUrl"/>

--- a/src/main/resources/templates/common.ftl
+++ b/src/main/resources/templates/common.ftl
@@ -103,3 +103,22 @@ Includes the wrapping form element, the generate label button and optionally the
 <#macro rescaledInternetLabellingFields>
   <@govukRadios.radio path="form.labelColour" radioItems=internetLabelColourOptions/>
 </#macro>
+
+<#macro labelTypeGuidanceMarch2021>
+  <@govukDetails.details summaryTitle="What kind of label should I choose?" detailsClass="govuk-!-margin-bottom-5">
+    <p>
+      If the product was first placed on the market on or after 1 November 2020, or hasn't been placed on the
+      market yet, you must use the new rescaled energy label.
+    </p>
+    <p>
+      The product's energy efficiency class on the rescaled label will be lower than its class on the old label, and
+      other values might also be calculated differently. Before you create a rescaled label, you need to make sure
+      the values you're entering are based on the criteria for the rescaled label. You shouldn't copy values directly
+      from the old label.
+    </p>
+    <p>
+      Products placed on the market before 1 November 2020 can continue to use the old style label until
+      30 November 2021.
+    </p>
+  </@govukDetails.details>
+</#macro>

--- a/src/main/resources/templates/govuk/details.ftl
+++ b/src/main/resources/templates/govuk/details.ftl
@@ -1,7 +1,7 @@
 <#--GOVUK Details-->
 <#--https://design-system.service.gov.uk/components/details/-->
-<#macro details summaryTitle>
-  <details class="govuk-details">
+<#macro details summaryTitle detailsClass="">
+  <details class="govuk-details<#if detailsClass?has_content> ${detailsClass}</#if>">
     <summary class="govuk-details__summary">
       <span class="govuk-details__summary-text">
         ${summaryTitle}

--- a/src/main/resources/templates/govuk/radio.ftl
+++ b/src/main/resources/templates/govuk/radio.ftl
@@ -101,7 +101,7 @@
   </#if>
 </#macro>
 
-<#macro radioGroup path nestingPath="" label="" hiddenContent=true legendSize="h1" showNestedForInternetLabels=true formGroupClass="">
+<#macro radioGroup path nestingPath="" label="" hiddenContent=true legendSize="h1" showNestedForInternetLabels=true isAboveDetailsComponent=false lastItemHasHiddenContent=false>
   <@spring.bind path/>
 
   <#local id=spring.status.expression?replace('[','')?replace(']','')>
@@ -114,8 +114,16 @@
   <#local displayValue=spring.status.displayValue>
   <#local hiddenField=hiddenFields?seq_contains(spring.status.path)!false>
 
+  <#assign marginClass>
+    <#if isAboveDetailsComponent && lastItemHasHiddenContent>
+      govuk-!-margin-bottom-0
+    <#elseif isAboveDetailsComponent>
+      govuk-!-margin-bottom-2
+    </#if>
+  </#assign>
+
   <#if !hiddenField>
-    <div class="govuk-form-group <#if hasError>govuk-form-group--error</#if> <#if formGroupClass?has_content>${formGroupClass}</#if>">
+    <div class="govuk-form-group <#if hasError>govuk-form-group--error</#if> <#if marginClass?has_content>${marginClass}</#if>">
       <@radioFieldset.fieldset legendHeading=fieldPrompt legendHeadingClass="govuk-fieldset__legend--s" legendSize=legendSize hintText=fieldHint hintTextId=id mandatory=true>
         <#if hasError>
           <span id="${id}-error" class="govuk-error-message">

--- a/src/main/resources/templates/govuk/radio.ftl
+++ b/src/main/resources/templates/govuk/radio.ftl
@@ -101,7 +101,7 @@
   </#if>
 </#macro>
 
-<#macro radioGroup path nestingPath="" label="" hiddenContent=true legendSize="h1" showNestedForInternetLabels=true>
+<#macro radioGroup path nestingPath="" label="" hiddenContent=true legendSize="h1" showNestedForInternetLabels=true formGroupClass="">
   <@spring.bind path/>
 
   <#local id=spring.status.expression?replace('[','')?replace(']','')>
@@ -115,7 +115,7 @@
   <#local hiddenField=hiddenFields?seq_contains(spring.status.path)!false>
 
   <#if !hiddenField>
-    <div class="govuk-form-group <#if hasError>govuk-form-group--error</#if>">
+    <div class="govuk-form-group <#if hasError>govuk-form-group--error</#if> <#if formGroupClass?has_content>${formGroupClass}</#if>">
       <@radioFieldset.fieldset legendHeading=fieldPrompt legendHeadingClass="govuk-fieldset__legend--s" legendSize=legendSize hintText=fieldHint hintTextId=id mandatory=true>
         <#if hasError>
           <span id="${id}-error" class="govuk-error-message">


### PR DESCRIPTION
- Hourly energy consumption field on air conditioners now specifies that it should be rounded up to the nearest integer (on cooling-only, heating-only and reversible single or double duct air conditioners)
- Energy consumption for TVs now accepts up to 4 digits for energy consumption for both SDR and HDR content
- Energy consumption for supermarket refrigerator/freezer cabinets now accepts up to 5 digits
- New wording and guidance for the 'What kind of label do you need to create?" question for dishwashers, fridges, wine storage appliances, TVs and washing machines.

Guidance wording in the 'What kind of label should I choose?' summary/details may change slightly based on BEIS feedback