### PR TITLE
Feature/readd rescaled lamps light sources

### DIFF
--- a/src/main/java/uk/gov/beis/els/categories/dishwashers/model/DishwashersForm.java
+++ b/src/main/java/uk/gov/beis/els/categories/dishwashers/model/DishwashersForm.java
@@ -14,7 +14,7 @@ import uk.gov.beis.els.model.meta.DualModeField;
 import uk.gov.beis.els.model.meta.FieldPrompt;
 import uk.gov.beis.els.model.meta.StaticProductText;
 
-@StaticProductText("You must attach the label to the front or top of the product so that it’s easy to see. If it's a built-in dishwasher it doesn't have to be attached to the product, but it must still be easy to see. Original-style labels must be at least 110mm x 220mm when printed. New-style 'rescaled' labels must be at least 96mm x 192mm when printed.")
+@StaticProductText("You must attach the label to the front or top of the product so that it’s easy to see. If it's a built-in dishwasher it doesn't have to be attached to the product, but it must still be easy to see. Old-style labels must be at least 110mm x 220mm when printed. New-style rescaled labels must be at least 96mm x 192mm when printed.")
 @GroupSequenceProvider(DishwashersFormSequenceProvider.class)
 public class DishwashersForm extends StandardTemplateForm30Char {
 

--- a/src/main/java/uk/gov/beis/els/categories/lamps/controller/LampsController.java
+++ b/src/main/java/uk/gov/beis/els/categories/lamps/controller/LampsController.java
@@ -25,6 +25,8 @@ import uk.gov.beis.els.categories.lamps.model.LampsCategory;
 import uk.gov.beis.els.categories.lamps.model.LampsForm;
 import uk.gov.beis.els.categories.lamps.model.LampsFormNoSupplierModel;
 import uk.gov.beis.els.categories.lamps.model.LampsFormNoSupplierModelConsumption;
+import uk.gov.beis.els.categories.lamps.model.LampsFormPackagingArrow;
+import uk.gov.beis.els.categories.lamps.model.LightSourceArrowOrientation;
 import uk.gov.beis.els.categories.lamps.model.TemplateColour;
 import uk.gov.beis.els.categories.lamps.model.TemplateSize;
 import uk.gov.beis.els.categories.lamps.service.LampsService;
@@ -42,7 +44,7 @@ import uk.gov.beis.els.util.StreamUtils;
 @RequestMapping("/categories/lamps")
 public class LampsController extends CategoryController {
 
-  private static final String BREADCRUMB_STAGE_TEXT = "Lamps";
+  private static final String BREADCRUMB_STAGE_TEXT = "Lamps and light sources";
 
   private final LampsService lampsService;
   private final BreadcrumbService breadcrumbService;
@@ -73,14 +75,17 @@ public class LampsController extends CategoryController {
   @PostMapping(value = "/lamps", params = "mode=INTERNET")
   @ResponseBody
   public Object handleInternetLabelLampsSubmit(@Validated(InternetLabellingGroup.class) @ModelAttribute("form") LampsForm form, BindingResult bindingResult) {
+    ControllerUtils.validateInternetLabelColour(form.getApplicableLegislation(), LampsService.LEGISLATION_CATEGORY_POST_SEPTEMBER_2021, bindingResult);
     return doIfValid(form, bindingResult, (category -> documentRendererService.processImageResponse(internetLabelService.generateInternetLabel(form, form.getEfficiencyRating(), category, ProductMetadata.LAMPS_FULL))));
   }
 
   private Object doIfValid(LampsForm form, BindingResult bindingResult, Function<SelectableLegislationCategory, ResponseEntity> function) {
+    ControllerUtils.validateRatingClassIfPopulated(form.getApplicableLegislation(), form.getEfficiencyRating(), LampsService.LEGISLATION_CATEGORIES, bindingResult);
     if (bindingResult.hasErrors()) {
       return getLamps(bindingResult.getFieldErrors());
     } else {
-      return function.apply(LampsService.LEGISLATION_CATEGORY_PRE_SEPTEMBER_2021);
+      SelectableLegislationCategory category = SelectableLegislationCategory.getById(form.getApplicableLegislation(), LampsService.LEGISLATION_CATEGORIES);
+      return function.apply(category);
     }
   }
 
@@ -138,14 +143,32 @@ public class LampsController extends CategoryController {
     }
   }
 
+  @GetMapping("/lamps-packaging-arrow")
+  public ModelAndView renderLampsPackagingArrow(@ModelAttribute("form") LampsFormPackagingArrow form) {
+    return getLampsPackagingArrow(Collections.emptyList());
+  }
+
+  @PostMapping("/lamps-packaging-arrow")
+  @ResponseBody
+  public Object handleLampsPackagingArrowSubmit(@Valid @ModelAttribute("form") LampsFormPackagingArrow form, BindingResult bindingResult) {
+    if (bindingResult.hasErrors()) {
+      return getLampsPackagingArrow(bindingResult.getFieldErrors());
+    }
+    else {
+      return documentRendererService.processPdfResponse(lampsService.generateHtml(form, LampsService.LEGISLATION_CATEGORY_POST_SEPTEMBER_2021));
+    }
+  }
+
   private ModelAndView getLamps(List<FieldError> errorList) {
     ModelAndView modelAndView = new ModelAndView("categories/lamps/lamps");
     addCommonObjects(modelAndView, errorList, ReverseRouter.route(on(LampsController.class).handleLampsSubmit(null, ReverseRouter.emptyBindingResult())));
-    modelAndView.addObject("efficiencyRating", ControllerUtils.ratingRangeToSelectionMap(LampsService.LEGISLATION_CATEGORY_PRE_SEPTEMBER_2021.getPrimaryRatingRange()));
+    modelAndView.addObject("efficiencyRating", ControllerUtils.combinedLegislationCategoryRangesToSelectionMap(LampsService.LEGISLATION_CATEGORIES));
+    modelAndView.addObject("legislationCategories", ControllerUtils.legislationCategorySelection(LampsService.LEGISLATION_CATEGORIES));
     modelAndView.addObject("templateSize",
         Arrays.stream(TemplateSize.values())
             .collect(StreamUtils.toLinkedHashMap(Enum::name, TemplateSize::getDisplayName))
     );
+    ControllerUtils.addShowRescaledInternetLabelGuidance(modelAndView);
     breadcrumbService.pushLastBreadcrumb(modelAndView, "Label with supplier's name, model identification code, rating and energy consumption");
     return modelAndView;
   }
@@ -163,6 +186,18 @@ public class LampsController extends CategoryController {
     addCommonObjects(modelAndView, errorList, ReverseRouter.route(on(LampsController.class).renderLampsExNameModelConsumption(null)));
     modelAndView.addObject("efficiencyRating", ControllerUtils.ratingRangeToSelectionMap(LampsService.LEGISLATION_CATEGORY_PRE_SEPTEMBER_2021.getPrimaryRatingRange()));
     breadcrumbService.pushLastBreadcrumb(modelAndView, "Label with energy rating only");
+    return modelAndView;
+  }
+
+  private ModelAndView getLampsPackagingArrow(List<FieldError> errorList) {
+    ModelAndView modelAndView = new ModelAndView("categories/lamps/lampsPackagingArrow");
+    addCommonObjects(modelAndView, errorList, ReverseRouter.route(on(LampsController.class).renderLampsPackagingArrow(null)));
+    modelAndView.addObject("efficiencyRating", ControllerUtils.ratingRangeToSelectionMap(LampsService.LEGISLATION_CATEGORY_POST_SEPTEMBER_2021.getPrimaryRatingRange()));
+    modelAndView.addObject("labelOrientationOptions",
+        Arrays.stream(LightSourceArrowOrientation.values())
+            .collect(StreamUtils.toLinkedHashMap(Enum::name, LightSourceArrowOrientation::getDisplayName))
+    );
+    breadcrumbService.pushLastBreadcrumb(modelAndView, "Arrow for packaging");
     return modelAndView;
   }
 

--- a/src/main/java/uk/gov/beis/els/categories/lamps/model/LampsCategory.java
+++ b/src/main/java/uk/gov/beis/els/categories/lamps/model/LampsCategory.java
@@ -15,30 +15,34 @@ public class LampsCategory implements Category {
   public static final Category GET = new LampsCategory();
 
   private static List<CategoryItem> subCategories = new ImmutableList.Builder<CategoryItem>()
-      .add(new CategoryItem(
-          "LAMPS",
-          "The energy rating, weighted energy consumption, the supplier's name and model identification code",
-          ReverseRouter.route(on(LampsController.class).renderLamps(null))))
-      .add(new CategoryItem(
-          "LAMPS_EX_NAME_MODEL",
-          "The energy rating and weighted energy consumption only",
-          ReverseRouter.route(on(LampsController.class).renderLampsExNameModel(null))))
-      .add(new CategoryItem(
-          "LAMPS_EX_NAME_MODEL_CONSUMPTION",
-          "The energy rating only",
-          ReverseRouter.route(on(LampsController.class).renderLampsExNameModelConsumption(null))))
-      .build();
+    .add(new CategoryItem(
+        "LAMPS",
+        "An original-style or new-style 'rescaled' label including the energy rating, weighted energy consumption, supplier's name and model identification code",
+        ReverseRouter.route(on(LampsController.class).renderLamps(null))))
+    .add(new CategoryItem(
+        "LAMPS_EX_NAME_MODEL",
+        "An original-style label including the energy rating and weighted energy consumption only",
+        ReverseRouter.route(on(LampsController.class).renderLampsExNameModel(null))))
+    .add(new CategoryItem(
+        "LAMPS_EX_NAME_MODEL_CONSUMPTION",
+        "An original-style label including the energy rating only",
+        ReverseRouter.route(on(LampsController.class).renderLampsExNameModelConsumption(null))))
+    .add(new CategoryItem(
+        "LAMPS_PACKAGING_ARROW",
+        "An arrow containing the energy rating for the front of the packaging, for products which use a new-style 'rescaled' label",
+        ReverseRouter.route(on(LampsController.class).renderLampsPackagingArrow(null))))
+    .build();
 
   private LampsCategory(){}
 
   @Override
   public String getCategoryQuestionText() {
-    return "What information should the label include about the lamp?";
+    return "What do you need to create?";
   }
 
   @Override
   public String getNoSelectionErrorMessage() {
-    return "Select the information which should be included on the label";
+    return "Select which type of label you need to create";
   }
 
   @Override

--- a/src/main/java/uk/gov/beis/els/categories/lamps/model/LampsCategory.java
+++ b/src/main/java/uk/gov/beis/els/categories/lamps/model/LampsCategory.java
@@ -17,19 +17,19 @@ public class LampsCategory implements Category {
   private static List<CategoryItem> subCategories = new ImmutableList.Builder<CategoryItem>()
     .add(new CategoryItem(
         "LAMPS",
-        "An original-style or new-style 'rescaled' label including the energy rating, weighted energy consumption, supplier's name and model identification code",
+        "An old-style or new-style rescaled label including the energy rating, weighted energy consumption, supplier's name and model identification code",
         ReverseRouter.route(on(LampsController.class).renderLamps(null))))
     .add(new CategoryItem(
         "LAMPS_EX_NAME_MODEL",
-        "An original-style label including the energy rating and weighted energy consumption only",
+        "An old-style label including the energy rating and weighted energy consumption only",
         ReverseRouter.route(on(LampsController.class).renderLampsExNameModel(null))))
     .add(new CategoryItem(
         "LAMPS_EX_NAME_MODEL_CONSUMPTION",
-        "An original-style label including the energy rating only",
+        "An old-style label including the energy rating only",
         ReverseRouter.route(on(LampsController.class).renderLampsExNameModelConsumption(null))))
     .add(new CategoryItem(
         "LAMPS_PACKAGING_ARROW",
-        "An arrow containing the energy rating for the front of the packaging, for products which use a new-style 'rescaled' label",
+        "An arrow containing the energy rating for the front of the packaging, for products which use a new-style rescaled label",
         ReverseRouter.route(on(LampsController.class).renderLampsPackagingArrow(null))))
     .build();
 

--- a/src/main/java/uk/gov/beis/els/categories/lamps/model/LampsForm.java
+++ b/src/main/java/uk/gov/beis/els/categories/lamps/model/LampsForm.java
@@ -12,9 +12,14 @@ import uk.gov.beis.els.model.meta.DualModeField;
 import uk.gov.beis.els.model.meta.FieldPrompt;
 import uk.gov.beis.els.model.meta.StaticProductText;
 
-@StaticProductText("The label should be at least 36mm x 76mm when attached to packaging. If it doesn’t fit, you can reduce the height by up to 60 percent. It can be full colour or black and white.")
+@StaticProductText("<p>Original-style labels must usually be at least 36mm x 75mm when attached to packaging. You can scale down the label if no side of the packaging is large enough to contain the label, or if the label would cover more than 50% of the surface area of the largest side. You must only scale down the label enough to meet these conditions, and the label must never be less than 14.4mm x 30mm.</p><p>New-style 'rescaled' labels must be at least 36mm x 72mm, or 20mm x 54mm for the small version of the label.</p>")
 @GroupSequenceProvider(LampsFormSequenceProvider.class)
 public class LampsForm extends StandardTemplateForm20Char {
+
+  @FieldPrompt("What kind of label do you need to create?")
+  @NotBlank(message = "Select the kind of label you need to create", groups = {Default.class, InternetLabellingGroup.class})
+  @DualModeField
+  private String applicableLegislation;
 
   @FieldPrompt("Energy efficiency class of the application")
   @NotBlank(message = "Select an energy efficiency class", groups = {Default.class, InternetLabellingGroup.class})
@@ -48,6 +53,14 @@ public class LampsForm extends StandardTemplateForm20Char {
 
   public void setEnergyConsumption(String energyConsumption) {
     this.energyConsumption = energyConsumption;
+  }
+
+  public String getApplicableLegislation() {
+    return applicableLegislation;
+  }
+
+  public void setApplicableLegislation(String applicableLegislation) {
+    this.applicableLegislation = applicableLegislation;
   }
 
   public String getTemplateSize() {

--- a/src/main/java/uk/gov/beis/els/categories/lamps/model/LampsForm.java
+++ b/src/main/java/uk/gov/beis/els/categories/lamps/model/LampsForm.java
@@ -12,7 +12,7 @@ import uk.gov.beis.els.model.meta.DualModeField;
 import uk.gov.beis.els.model.meta.FieldPrompt;
 import uk.gov.beis.els.model.meta.StaticProductText;
 
-@StaticProductText("<p>Original-style labels must usually be at least 36mm x 75mm when attached to packaging. You can scale down the label if no side of the packaging is large enough to contain the label, or if the label would cover more than 50% of the surface area of the largest side. You must only scale down the label enough to meet these conditions, and the label must never be less than 14.4mm x 30mm.</p><p>New-style 'rescaled' labels must be at least 36mm x 72mm, or 20mm x 54mm for the small version of the label.</p>")
+@StaticProductText("<p>Old-style labels must usually be at least 36mm x 75mm when attached to packaging. You can scale down the label if no side of the packaging is large enough to contain the label, or if the label would cover more than 50% of the surface area of the largest side. You must only scale down the label enough to meet these conditions, and the label must never be less than 14.4mm x 30mm.</p><p>New-style rescaled labels must be at least 36mm x 72mm, or 20mm x 54mm for the small version of the label.</p>")
 @GroupSequenceProvider(LampsFormSequenceProvider.class)
 public class LampsForm extends StandardTemplateForm20Char {
 
@@ -36,7 +36,7 @@ public class LampsForm extends StandardTemplateForm20Char {
   private String templateSize;
 
   @FieldPrompt(value = "Should the label be in colour or black and white?", hintText = "You must only use a black and white label if all other information on the packaging, including graphics, is printed in black and white")
-  @NotBlank(message = "Select whether the label be in colour or black and white", groups = {PostSeptember2021Field.class})
+  @NotBlank(message = "Select whether the label should be in colour or black and white", groups = {PostSeptember2021Field.class})
   private String templateColour;
 
   public String getEfficiencyRating() {

--- a/src/main/java/uk/gov/beis/els/categories/lamps/model/LampsFormNoSupplierModel.java
+++ b/src/main/java/uk/gov/beis/els/categories/lamps/model/LampsFormNoSupplierModel.java
@@ -22,7 +22,7 @@ public class LampsFormNoSupplierModel extends InternetLabellingForm {
   private String energyConsumption;
 
   @FieldPrompt("Should the label be in colour or black and white?")
-  @NotBlank(message = "Select whether the label be in colour or black and white")
+  @NotBlank(message = "Select whether the label should be in colour or black and white")
   private String templateColour;
 
   public String getEfficiencyRating() {

--- a/src/main/java/uk/gov/beis/els/categories/lamps/model/LampsFormNoSupplierModelConsumption.java
+++ b/src/main/java/uk/gov/beis/els/categories/lamps/model/LampsFormNoSupplierModelConsumption.java
@@ -17,7 +17,7 @@ public class LampsFormNoSupplierModelConsumption extends InternetLabellingForm {
   private String efficiencyRating;
 
   @FieldPrompt("Should the label be in colour or black and white?")
-  @NotBlank(message = "Select whether the label be in colour or black and white")
+  @NotBlank(message = "Select whether the label should be in colour or black and white")
   private String templateColour;
 
   public String getEfficiencyRating() {

--- a/src/main/java/uk/gov/beis/els/categories/lamps/model/validation/LampsFormSequenceProvider.java
+++ b/src/main/java/uk/gov/beis/els/categories/lamps/model/validation/LampsFormSequenceProvider.java
@@ -4,12 +4,22 @@ import java.util.ArrayList;
 import java.util.List;
 import org.hibernate.validator.spi.group.DefaultGroupSequenceProvider;
 import uk.gov.beis.els.categories.lamps.model.LampsForm;
+import uk.gov.beis.els.categories.common.PostSeptember2021Field;
+import uk.gov.beis.els.categories.common.PreSeptember2021Field;
+import uk.gov.beis.els.categories.lamps.service.LampsService;
 
 public class LampsFormSequenceProvider implements DefaultGroupSequenceProvider<LampsForm> {
   @Override
   public List<Class<?>> getValidationGroups(LampsForm form) {
     List<Class<?>> sequence = new ArrayList<>();
 
+    if (form != null) {
+      if (LampsService.LEGISLATION_CATEGORY_PRE_SEPTEMBER_2021.getId().equals(form.getApplicableLegislation())) {
+        sequence.add(PreSeptember2021Field.class);
+      } else if (LampsService.LEGISLATION_CATEGORY_POST_SEPTEMBER_2021.getId().equals(form.getApplicableLegislation())) {
+        sequence.add(PostSeptember2021Field.class);
+      }
+    }
     sequence.add(LampsForm.class);
     return sequence;
   }

--- a/src/main/java/uk/gov/beis/els/categories/lamps/service/LampsService.java
+++ b/src/main/java/uk/gov/beis/els/categories/lamps/service/LampsService.java
@@ -30,8 +30,8 @@ public class LampsService {
   public static final SelectableLegislationCategory LEGISLATION_CATEGORY_POST_SEPTEMBER_2021 = SelectableLegislationCategory.postSeptember2021();
 
   public static final List<SelectableLegislationCategory> LEGISLATION_CATEGORIES = new ImmutableList.Builder<SelectableLegislationCategory>()
-          .add(LEGISLATION_CATEGORY_PRE_SEPTEMBER_2021)
           .add(LEGISLATION_CATEGORY_POST_SEPTEMBER_2021)
+          .add(LEGISLATION_CATEGORY_PRE_SEPTEMBER_2021)
           .build();
 
   private final TemplateParserService templateParserService;

--- a/src/main/java/uk/gov/beis/els/categories/refrigeratingappliances/model/RefrigeratingAppliancesCategory.java
+++ b/src/main/java/uk/gov/beis/els/categories/refrigeratingappliances/model/RefrigeratingAppliancesCategory.java
@@ -38,7 +38,7 @@ public class RefrigeratingAppliancesCategory implements Category {
 
   @Override
   public String getCommonProductGuidanceText() {
-    return "You must attach the label to the front or top of the product so that it’s easy to see. If it's a built-in appliance it doesn't have to be attached to the product, but it must still be easy to see. Original-style labels must be at least 110mm x 220mm when printed. New-style 'rescaled' labels must be at least 96mm x 192mm when printed.";
+    return "You must attach the label to the front or top of the product so that it’s easy to see. If it's a built-in appliance it doesn't have to be attached to the product, but it must still be easy to see. Old-style labels must be at least 110mm x 220mm when printed. New-style rescaled labels must be at least 96mm x 192mm when printed.";
   }
 
   @Override

--- a/src/main/java/uk/gov/beis/els/categories/televisions/model/TelevisionsForm.java
+++ b/src/main/java/uk/gov/beis/els/categories/televisions/model/TelevisionsForm.java
@@ -15,7 +15,7 @@ import uk.gov.beis.els.model.meta.DualModeField;
 import uk.gov.beis.els.model.meta.FieldPrompt;
 import uk.gov.beis.els.model.meta.StaticProductText;
 
-@StaticProductText("<p>You must display the label so that it’s easy to see and clearly related to the product.</p> <p>Original-style labels must be at least 60mm x 120mm when printed.</p><p>New-style 'rescaled' labels must usually be at least 96mm x 192mm when printed. If the diagonal size of the visible screen area is less than 127cm (50 inches) you can scale down the the label, but it must still be at least 57.6mm x 115.2mm. If you scale down the label you must test that the QR code can still be read when printed, for example by using a smartphone camera.</p>")
+@StaticProductText("<p>You must display the label so that it’s easy to see and clearly related to the product.</p> <p>Old-style labels must be at least 60mm x 120mm when printed.</p><p>New-style rescaled labels must usually be at least 96mm x 192mm when printed. If the diagonal size of the visible screen area is less than 127cm (50 inches) you can scale down the the label, but it must still be at least 57.6mm x 115.2mm. If you scale down the label you must test that the QR code can still be read when printed, for example by using a smartphone camera.</p>")
 @GroupSequenceProvider(TelevisionsFormSequenceProvider.class)
 public class TelevisionsForm extends StandardTemplateForm30Char {
 

--- a/src/main/java/uk/gov/beis/els/categories/washingmachines/model/WashingMachinesForm.java
+++ b/src/main/java/uk/gov/beis/els/categories/washingmachines/model/WashingMachinesForm.java
@@ -14,7 +14,7 @@ import uk.gov.beis.els.model.meta.DualModeField;
 import uk.gov.beis.els.model.meta.FieldPrompt;
 import uk.gov.beis.els.model.meta.StaticProductText;
 
-@StaticProductText("You must attach the label to the front or top of the product so that it’s easy to see. If it's a built-in washing machine it doesn't have to be attached to the product, but it must still be easy to see. Original-style labels must be at least 110mm x 220mm when printed. New-style 'rescaled' labels must be at least 96mm x 192mm when printed.")
+@StaticProductText("You must attach the label to the front or top of the product so that it’s easy to see. If it's a built-in washing machine it doesn't have to be attached to the product, but it must still be easy to see. Old-style labels must be at least 110mm x 220mm when printed. New-style rescaled labels must be at least 96mm x 192mm when printed.")
 @GroupSequenceProvider(WashingMachineFormSequenceProvider.class)
 public class WashingMachinesForm extends StandardTemplateForm30Char {
 

--- a/src/main/java/uk/gov/beis/els/model/ProductCategory.java
+++ b/src/main/java/uk/gov/beis/els/model/ProductCategory.java
@@ -43,7 +43,7 @@ public class ProductCategory implements Category {
           ReverseRouter.route(on(RefrigeratingAppliancesController.class).handleCategoriesSubmit(null, ReverseRouter.emptyBindingResult()))))
       .add(new CategoryItem(
           "LAMPS",
-          "Lamps",
+          "Lamps and light sources",
           ReverseRouter.route(on(LampsController.class).handleCategoriesSubmit(null, ReverseRouter.emptyBindingResult()))))
       .add(new CategoryItem(
           "LOCAL_SPACE_HEATERS",

--- a/src/main/java/uk/gov/beis/els/model/ProductMetadata.java
+++ b/src/main/java/uk/gov/beis/els/model/ProductMetadata.java
@@ -24,7 +24,7 @@ public enum ProductMetadata {
   HRA_FRIDGE_FREEZER("Household refrigerating appliances - Fridges and freezers", "Refrigerating appliances"),
   HRA_WINE_STORAGE("Household refrigerating appliances - Wine storage appliances", "Refrigerating appliances"),
 
-  LAMPS_FULL("Lamps - Label with supplier's name, identification code, rating and energy consumption", "Lamps"),
+  LAMPS_FULL("Lamps and light sources - Label with supplier's name, identification code, rating and energy consumption", "Lamps and light sources"),
   LAMPS_RATING_CONSUMPTION("Lamps - Label with energy rating and weighted energy consumption only", "Lamps"),
   LAMPS_RATING("Lamps - Label with energy rating only", "Lamps"),
   LAMPS_PACKAGING_ARROW("Lamps and light sources - Packaging arrow", "Lamps and light sources"),

--- a/src/main/java/uk/gov/beis/els/model/SelectableLegislationCategory.java
+++ b/src/main/java/uk/gov/beis/els/model/SelectableLegislationCategory.java
@@ -39,11 +39,11 @@ public class SelectableLegislationCategory extends LegislationCategory {
   }
 
   public static SelectableLegislationCategory preSeptember2021(RatingClassRange primaryRatingRange) {
-    return new SelectableLegislationCategory("PRE_SEPT2021", "An original-style label for display before 1 September 2021", primaryRatingRange, null);
+    return new SelectableLegislationCategory("PRE_SEPT2021", "An old-style energy label", primaryRatingRange, null);
   }
 
   public static SelectableLegislationCategory postSeptember2021() {
-    return new SelectableLegislationCategory("POST_SEPT2021", "A new-style 'rescaled' label for display after 1 September 2021", RatingClassRange.of(RatingClass.A, RatingClass.G), null, InternetLabelTemplate.RESCALED);
+    return new SelectableLegislationCategory("POST_SEPT2021", "A new-style rescaled energy label", RatingClassRange.of(RatingClass.A, RatingClass.G), null, InternetLabelTemplate.RESCALED);
   }
 
   public SelectableLegislationCategory(String id, String displayName, RatingClassRange primaryRatingRange, RatingClassRange secondaryRatingRange) {

--- a/src/main/resources/templates/categories/lamps/lamps.ftl
+++ b/src/main/resources/templates/categories/lamps/lamps.ftl
@@ -1,6 +1,31 @@
 <#include '../../layout.ftl'>
 
-<@common.standardProductForm "Lamps">
+<@common.standardProductForm "Lamps and light sources">
+  <@govukRadios.radioGroup path="form.applicableLegislation" legendSize="h2" isAboveDetailsComponent=true>
+    <@common.postSeptember2021RadioItem legislationCategories>
+      <@govukTextInput.textInput path="form.qrCodeUrl" fieldHintOverride="This link will be shown as a QR code on the label. Links should be under 100 characters to make sure they can be scanned reliably. "/>
+      <@govukRadios.radio path="form.templateSize" radioItems=templateSize legendSize="h2"/>
+      <@govukRadios.radio path="form.templateColour" radioItems=templateColour legendSize="h2"/>
+    </@common.postSeptember2021RadioItem>
+    <@common.preSeptember2021RadioItem legislationCategories/>
+  </@govukRadios.radioGroup>
+
+  <@govukDetails.details summaryTitle="What kind of label should I choose?" detailsClass="govuk-!-margin-bottom-5">
+    <p>
+      The government will implement a rescaled energy label for lighting products in Great Britain from
+      September 2021. You can begin preparing for this now.
+    </p>
+    <p>
+      The product's energy efficiency class on the rescaled label will be lower than its class on the old label, and
+      other values might also be calculated differently. Before you create a rescaled label, you need to make sure
+      the values you're entering are based on the criteria for the rescaled label. You shouldn't copy values directly
+      from the old label.
+    </p>
+    <p>
+      Products that are currently on the market, or placed on the market before these updated requirements begin to
+      apply, should still use the old-style energy label.
+    </p>
+  </@govukDetails.details>
   <@govukSelect.select path="form.efficiencyRating" options=efficiencyRating/>
   <@govukTextInput.textInput path="form.energyConsumption"/>
 </@common.standardProductForm>

--- a/src/main/resources/templates/categories/lamps/lampsPackagingArrow.ftl
+++ b/src/main/resources/templates/categories/lamps/lampsPackagingArrow.ftl
@@ -1,6 +1,10 @@
 <#include '../../layout.ftl'>
 
 <@common.standardProductForm title="Energy rating arrow for light source packaging" includeSupplierNameModel=false showInsetText=false>
+  <div class="govuk-inset-text">
+    The government will implement a rescaled energy label for lighting products in Great Britain from September 2021.
+    You can begin preparing for this now. This arrow must only be used on products which include a new-style rescaled energy label.
+  </div>
   <@govukSelect.select path="form.efficiencyRating" options=efficiencyRating/>
   <@govukRadios.radio path="form.templateColour" radioItems=templateColour legendSize="h2"/>
   <@govukRadios.radio path="form.labelOrientation" radioItems=labelOrientationOptions legendSize="h2"/>

--- a/src/main/resources/templates/categories/refrigerators-direct-sales/beverageCoolers.ftl
+++ b/src/main/resources/templates/categories/refrigerators-direct-sales/beverageCoolers.ftl
@@ -1,6 +1,11 @@
 <#include '../../layout.ftl'>
 
-<@common.standardProductForm title="Beverage coolers" includeRescaledInternetLabellingFields=true>
+<@common.standardProductForm
+  title="Beverage coolers"
+  includeRescaledInternetLabellingFields=true
+  beforeStandardInsetText="From summer 2021 an energy label will apply to beverage coolers.
+  These products will be required to display an energy label when placed on the market."
+>
   <@govukTextInput.textInput path="form.qrCodeUrl"/>
   <@govukSelect.select path="form.efficiencyRating" options=efficiencyRating/>
   <@govukTextInput.textInput path="form.annualEnergyConsumption"/>

--- a/src/main/resources/templates/categories/refrigerators-direct-sales/displayCabinets.ftl
+++ b/src/main/resources/templates/categories/refrigerators-direct-sales/displayCabinets.ftl
@@ -1,6 +1,12 @@
 <#include '../../layout.ftl'>
 
-<@common.standardProductForm title="Supermarket refrigerator/freezer cabinets or gelato-scooping cabinets" includeRescaledInternetLabellingFields=true>
+<@common.standardProductForm
+  title="Supermarket refrigerator/freezer cabinets or gelato-scooping cabinets"
+  includeRescaledInternetLabellingFields=true
+  beforeStandardInsetText="From summer 2021 an energy label will apply to supermarket refrigerator and freezer cabinets,
+  and gelato-scooping cabinets.
+  These products will be required to display an energy label when placed on the market."
+>
   <@govukTextInput.textInput path="form.qrCodeUrl"/>
   <@govukSelect.select path="form.efficiencyRating" options=efficiencyRating/>
   <@govukTextInput.textInput path="form.annualEnergyConsumption"/>

--- a/src/main/resources/templates/categories/refrigerators-direct-sales/iceCreamFreezers.ftl
+++ b/src/main/resources/templates/categories/refrigerators-direct-sales/iceCreamFreezers.ftl
@@ -1,6 +1,10 @@
 <#include '../../layout.ftl'>
 
-<@common.standardProductForm title="Ice cream freezers" includeRescaledInternetLabellingFields=true>
+<@common.standardProductForm
+title="Ice cream freezers"
+includeRescaledInternetLabellingFields=true
+beforeStandardInsetText="From summer 2021 an energy label will apply to ice cream freezers.
+These products will be required to display an energy label when placed on the market.">
   <@govukTextInput.textInput path="form.qrCodeUrl"/>
   <@govukSelect.select path="form.efficiencyRating" options=efficiencyRating/>
   <@govukTextInput.textInput path="form.annualEnergyConsumption"/>

--- a/src/main/resources/templates/categories/refrigerators-direct-sales/vendingMachines.ftl
+++ b/src/main/resources/templates/categories/refrigerators-direct-sales/vendingMachines.ftl
@@ -1,6 +1,10 @@
 <#include '../../layout.ftl'>
 
-<@common.standardProductForm title="Refrigerated vending machines" includeRescaledInternetLabellingFields=true>
+<@common.standardProductForm
+  title="Refrigerated vending machines"
+  includeRescaledInternetLabellingFields=true
+  beforeStandardInsetText="From summer 2021 an energy label will apply to refrigerated vending machines.
+  These products will be required to display an energy label when placed on the market.">
   <@govukTextInput.textInput path="form.qrCodeUrl"/>
   <@govukSelect.select path="form.efficiencyRating" options=efficiencyRating/>
   <@govukTextInput.textInput path="form.annualEnergyConsumption"/>

--- a/src/main/resources/templates/common.ftl
+++ b/src/main/resources/templates/common.ftl
@@ -41,9 +41,9 @@
 
 <#-- Template for standard product forms.
 Includes the wrapping form element, the generate label button and optionally the supplier name and model fields -->
-<#macro standardProductForm title includeSupplierNameModel=true includeRescaledInternetLabellingFields=false showInsetText=true>
+<#macro standardProductForm title includeSupplierNameModel=true includeRescaledInternetLabellingFields=false showInsetText=true beforeStandardInsetText="">
 
-  <@defaultPage pageHeading=title showInsetText=showInsetText>
+  <@defaultPage pageHeading=title showInsetText=showInsetText beforeStandardInsetText=beforeStandardInsetText>
     <@form.govukForm submitUrl + modeQueryParam!"">
 
       <#if includeSupplierNameModel>

--- a/src/main/resources/templates/govuk/textInput.ftl
+++ b/src/main/resources/templates/govuk/textInput.ftl
@@ -3,14 +3,14 @@
 
 <#--GOVUK Input-->
 <#--https://design-system.service.gov.uk/components/text-input/-->
-<#macro textInput path label="" inputWidth="govuk-input--width-100">
+<#macro textInput path label="" inputWidth="govuk-input--width-100" fieldHintOverride="">
   <@spring.bind path/>
 
   <#local id=spring.status.expression?replace('[','')?replace(']','')>
   <#local hasError=(spring.status.errorMessages?size > 0)>
   <#local mandatory=((validation[spring.status.path].mandatory)!false)>
   <#local fieldPrompt=(fieldPromptMapping[spring.status.path].value())!label>
-  <#local fieldHint=(fieldPromptMapping[spring.status.path].hintText())!>
+  <#local fieldHint=fieldHintOverride?has_content?then(fieldHintOverride, (fieldPromptMapping[spring.status.path].hintText())!)>
   <#local fieldWidth=fieldWidthMapping[spring.status.path]!>
   <#local hiddenField=hiddenFields?seq_contains(spring.status.path)!false>
   <#local numericField=(numericFields?seq_contains(spring.status.path))!false>

--- a/src/main/resources/templates/layout.ftl
+++ b/src/main/resources/templates/layout.ftl
@@ -39,6 +39,7 @@
   showBreadcrumbs=true
   pageScripts=blankMacro
   notificationBanner=blankMacro
+  beforeStandardInsetText=""
   >
 
   <#--Checks if the heading has content in order to not display an empty <h1>-->
@@ -125,6 +126,11 @@
 
               <#if showInsetText>
                 <div class="govuk-inset-text">
+                  <#if beforeStandardInsetText?has_content>
+                    <p>
+                      ${beforeStandardInsetText}
+                    </p>
+                  </#if>
                   <#if labelMode?has_content && labelMode=='INTERNET'>
                     <#if showRescaledInternetLabelGuidance>
                       <p>


### PR DESCRIPTION
- Reintroduced the rescaled lamps labels backed out in f466b6e3bb5039e06f38793780bf29fc354d27a2
- Add introduction date guidance for rescaled lamps
- Add introduction date guidance for each direct sales refrigerator category
- Change 'original-style label' references in guidance to 'old-style label' for consistency with radio buttons