### PR TITLE
ELG-14 APIs for range hoods

### DIFF
--- a/src/main/java/uk/gov/beis/els/api/categories/rangehoods/RangeHoodsApiController.java
+++ b/src/main/java/uk/gov/beis/els/api/categories/rangehoods/RangeHoodsApiController.java
@@ -1,0 +1,53 @@
+package uk.gov.beis.els.api.categories.rangehoods;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import javax.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import uk.gov.beis.els.categories.internetlabelling.service.InternetLabelService;
+import uk.gov.beis.els.categories.rangehoods.model.RangeHoodsForm;
+import uk.gov.beis.els.categories.rangehoods.service.RangeHoodsService;
+import uk.gov.beis.els.model.ProductMetadata;
+import uk.gov.beis.els.service.DocumentRendererService;
+
+@RestController
+@RequestMapping("${api.v1.base_path}/range-hoods")
+@Tag(name = "Range hoods")
+public class RangeHoodsApiController {
+
+  private final RangeHoodsService rangeHoodsService;
+  private final InternetLabelService internetLabelService;
+  private final DocumentRendererService documentRendererService;
+
+  @Autowired
+  public RangeHoodsApiController(RangeHoodsService rangeHoodsService,
+                                 InternetLabelService internetLabelService,
+                                 DocumentRendererService documentRendererService) {
+    this.rangeHoodsService = rangeHoodsService;
+    this.internetLabelService = internetLabelService;
+    this.documentRendererService = documentRendererService;
+  }
+
+  @Operation(
+      summary = "Create energy label for range hood",
+      description = "You must display the label so that it’s easy to see and clearly related to the product. It must be at least 60mm x 120mm when printed."
+  )
+  @PostMapping("/range-hoods/energy-label")
+  public Object rangeHoods(@RequestBody @Valid RangeHoodsForm form) {
+    return documentRendererService.processPdfApiResponse(
+        rangeHoodsService.generateHtml(form, RangeHoodsService.LEGISLATION_CATEGORY_CURRENT));
+  }
+
+  @Operation(summary = "Create an internet label for a range hood")
+  @PostMapping("/range-hoods/internet-label")
+  public Object rangeHoodsInternetLabel(@RequestBody @Valid RangeHoodsInternetLabelApiForm form) {
+    return documentRendererService.processImageApiResponse(
+        internetLabelService.generateInternetLabel(form, form.getEfficiencyRating(),
+            RangeHoodsService.LEGISLATION_CATEGORY_CURRENT,
+            ProductMetadata.RANGE_HOODS));
+  }
+}

--- a/src/main/java/uk/gov/beis/els/api/categories/rangehoods/RangeHoodsApiController.java
+++ b/src/main/java/uk/gov/beis/els/api/categories/rangehoods/RangeHoodsApiController.java
@@ -15,7 +15,7 @@ import uk.gov.beis.els.model.ProductMetadata;
 import uk.gov.beis.els.service.DocumentRendererService;
 
 @RestController
-@RequestMapping("${api.v1.base_path}/range-hoods")
+@RequestMapping("${api.v1.base_path}")
 @Tag(name = "Range hoods")
 public class RangeHoodsApiController {
 

--- a/src/main/java/uk/gov/beis/els/api/categories/rangehoods/RangeHoodsInternetLabelApiForm.java
+++ b/src/main/java/uk/gov/beis/els/api/categories/rangehoods/RangeHoodsInternetLabelApiForm.java
@@ -1,0 +1,24 @@
+package uk.gov.beis.els.api.categories.rangehoods;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import javax.validation.constraints.NotBlank;
+import uk.gov.beis.els.api.common.ApiValuesFromLegislationCategory;
+import uk.gov.beis.els.api.common.BaseInternetLabelApiForm;
+import uk.gov.beis.els.categories.rangehoods.service.RangeHoodsService;
+
+@Schema(name = "Range hood internet label")
+public class RangeHoodsInternetLabelApiForm extends BaseInternetLabelApiForm {
+
+  @Schema(description = "Energy efficiency class indicator")
+  @NotBlank
+  @ApiValuesFromLegislationCategory(serviceClass = RangeHoodsService.class)
+  private String efficiencyRating;
+
+  public String getEfficiencyRating() {
+    return efficiencyRating;
+  }
+
+  public void setEfficiencyRating(String efficiencyRating) {
+    this.efficiencyRating = efficiencyRating;
+  }
+}

--- a/src/main/java/uk/gov/beis/els/api/common/ApiValuesFromLegislationCategory.java
+++ b/src/main/java/uk/gov/beis/els/api/common/ApiValuesFromLegislationCategory.java
@@ -24,4 +24,9 @@ public @interface ApiValuesFromLegislationCategory {
    * @return The name of the LegislationCategory field
    */
   String legislationCategoryFieldName() default "LEGISLATION_CATEGORY_CURRENT";
+
+  /**
+   * @return whether to use the second range of a LegislationCategory for efficiency ratings
+   */
+  boolean useSecondaryRange() default false;
 }

--- a/src/main/java/uk/gov/beis/els/api/openapi/OpenApiPropertyCustomiser.java
+++ b/src/main/java/uk/gov/beis/els/api/openapi/OpenApiPropertyCustomiser.java
@@ -37,8 +37,8 @@ public class OpenApiPropertyCustomiser implements PropertyCustomizer {
         .filter(annotation::isInstance)
         .map(annotation::cast)
         .findFirst();
-  } 
-  
+  }
+
   /**
    * Sets the description field based on the FieldPrompt and optional Digits annotations, if it has not been overridden
    * by a description defined by the Schema annotation.
@@ -87,8 +87,17 @@ public class OpenApiPropertyCustomiser implements PropertyCustomizer {
       .ifPresent(apiValueAnnotation -> {
         try {
           Field field = apiValueAnnotation.serviceClass().getField(apiValueAnnotation.legislationCategoryFieldName());
-          LegislationCategory legislationCategory = (LegislationCategory) field.get(null); // Null as we're accessing a static field
-          RatingClassRange range = legislationCategory.getPrimaryRatingRange();
+          RatingClassRange range;
+
+          if (field.get(null).getClass().equals(LegislationCategory.class)) {
+            LegislationCategory legislationCategory = (LegislationCategory) field.get(
+                null); // Null as we're accessing a static field
+            range = legislationCategory.getPrimaryRatingRange();
+          } else if (field.get(null).getClass().equals(RatingClassRange.class)) {
+            range = (RatingClassRange) field.get(null);
+          } else {
+            throw new RuntimeException("cannot unwrap field");
+          }
 
           List<String> allowedValues = range.getApplicableRatings().stream()
               .map(RatingClass::name) // TODO may be nicer to accept the display value i.e 'A++' rather than 'APP'

--- a/src/main/java/uk/gov/beis/els/categories/rangehoods/controller/RangeHoodsController.java
+++ b/src/main/java/uk/gov/beis/els/categories/rangehoods/controller/RangeHoodsController.java
@@ -77,7 +77,7 @@ public class RangeHoodsController {
   private ModelAndView getRangeHoodsForm(List<FieldError> errorList) {
     ModelAndView modelAndView = new ModelAndView("categories/range-hoods/rangeHoods");
     modelAndView.addObject("efficiencyRating", ControllerUtils.ratingRangeToSelectionMap(RangeHoodsService.LEGISLATION_CATEGORY_CURRENT.getPrimaryRatingRange()));
-    modelAndView.addObject("secondaryRating", ControllerUtils.ratingRangeToSelectionMap(RangeHoodsService.SECONDARY_CLASS_RANGE));
+    modelAndView.addObject("secondaryRating", ControllerUtils.ratingRangeToSelectionMap(RangeHoodsService.LEGISLATION_CATEGORY_CURRENT.getSecondaryRatingRange()));
     modelAndView.addObject("submitUrl", ReverseRouter.route(on(RangeHoodsController.class).handleRangeHoodsFormSubmit(null, ReverseRouter.emptyBindingResult())));
     ControllerUtils.addErrorSummary(modelAndView, errorList);
     breadcrumbService.addLastBreadcrumbToModel(modelAndView, BREADCRUMB_STAGE_TEXT);

--- a/src/main/java/uk/gov/beis/els/categories/rangehoods/model/RangeHoodsForm.java
+++ b/src/main/java/uk/gov/beis/els/categories/rangehoods/model/RangeHoodsForm.java
@@ -36,7 +36,7 @@ public class RangeHoodsForm extends StandardTemplateForm30Char {
   @NotBlank(message = "Select a fluid dynamic efficiency class")
   @ApiValuesFromLegislationCategory(
       serviceClass = RangeHoodsService.class,
-      legislationCategoryFieldName = "SECONDARY_CLASS_RANGE"
+      useSecondaryRange = true
   )
   private String fluidClass;
 
@@ -48,7 +48,7 @@ public class RangeHoodsForm extends StandardTemplateForm30Char {
   @NotBlank(message = "Select a lighting efficiency class", groups = {LightingSystemGroup.class})
   @ApiValuesFromLegislationCategory(
       serviceClass = RangeHoodsService.class,
-      legislationCategoryFieldName = "SECONDARY_CLASS_RANGE"
+      useSecondaryRange = true
   )
   private String lightingClass;
 
@@ -56,7 +56,7 @@ public class RangeHoodsForm extends StandardTemplateForm30Char {
   @NotBlank(message = "Select a grease filtering efficiency class")
   @ApiValuesFromLegislationCategory(
       serviceClass = RangeHoodsService.class,
-      legislationCategoryFieldName = "SECONDARY_CLASS_RANGE"
+      useSecondaryRange = true
   )
   private String greaseClass;
 

--- a/src/main/java/uk/gov/beis/els/categories/rangehoods/model/RangeHoodsForm.java
+++ b/src/main/java/uk/gov/beis/els/categories/rangehoods/model/RangeHoodsForm.java
@@ -1,17 +1,21 @@
 package uk.gov.beis.els.categories.rangehoods.model;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import javax.validation.constraints.Digits;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.groups.Default;
 import org.hibernate.validator.group.GroupSequenceProvider;
+import uk.gov.beis.els.api.common.ApiValuesFromLegislationCategory;
 import uk.gov.beis.els.categories.common.StandardTemplateForm30Char;
 import uk.gov.beis.els.categories.internetlabelling.model.InternetLabellingGroup;
 import uk.gov.beis.els.categories.rangehoods.RangeHoodsFormSequenceProvider;
+import uk.gov.beis.els.categories.rangehoods.service.RangeHoodsService;
 import uk.gov.beis.els.model.meta.DualModeField;
 import uk.gov.beis.els.model.meta.FieldPrompt;
 import uk.gov.beis.els.model.meta.StaticProductText;
 
+@Schema(name = "Range hood energy label")
 @GroupSequenceProvider(RangeHoodsFormSequenceProvider.class)
 @StaticProductText("You must display the label so that it’s easy to see and clearly related to the product. It must be at least 60mm x 120mm when printed.")
 public class RangeHoodsForm extends StandardTemplateForm30Char {
@@ -19,14 +23,21 @@ public class RangeHoodsForm extends StandardTemplateForm30Char {
   @FieldPrompt("Energy efficiency class indicator")
   @NotBlank(message = "Select an energy efficiency indicator" , groups = {Default.class, InternetLabellingGroup.class})
   @DualModeField
+  @ApiValuesFromLegislationCategory(serviceClass = RangeHoodsService.class)
   private String efficiencyRating;
 
   @FieldPrompt("Annual energy consumption - AEC hood (kWh/annum)")
   @Digits(integer = 3, fraction = 0, message = "Enter the annual energy consumption, up to 3 digits long")
+  @Schema(type = "integer")
+  @NotNull
   private String annualEnergyConsumption;
 
   @FieldPrompt("The Fluid Dynamic Efficiency class")
   @NotBlank(message = "Select a fluid dynamic efficiency class")
+  @ApiValuesFromLegislationCategory(
+      serviceClass = RangeHoodsService.class,
+      legislationCategoryFieldName = "SECONDARY_CLASS_RANGE"
+  )
   private String fluidClass;
 
   @FieldPrompt(value = "Does this model have a lighting system?")
@@ -35,14 +46,24 @@ public class RangeHoodsForm extends StandardTemplateForm30Char {
 
   @FieldPrompt("The Lighting Efficiency class")
   @NotBlank(message = "Select a lighting efficiency class", groups = {LightingSystemGroup.class})
+  @ApiValuesFromLegislationCategory(
+      serviceClass = RangeHoodsService.class,
+      legislationCategoryFieldName = "SECONDARY_CLASS_RANGE"
+  )
   private String lightingClass;
 
   @FieldPrompt("The Grease Filtering Efficiency class")
   @NotBlank(message = "Select a grease filtering efficiency class")
+  @ApiValuesFromLegislationCategory(
+      serviceClass = RangeHoodsService.class,
+      legislationCategoryFieldName = "SECONDARY_CLASS_RANGE"
+  )
   private String greaseClass;
 
   @FieldPrompt("The Noise Value (dB)")
   @Digits(integer = 2, fraction = 0, message = "Enter the noise value, up to 2 digits long")
+  @Schema(type = "integer")
+  @NotNull
   private String noiseValue;
 
   public String getEfficiencyRating() {

--- a/src/main/java/uk/gov/beis/els/categories/rangehoods/service/RangeHoodsService.java
+++ b/src/main/java/uk/gov/beis/els/categories/rangehoods/service/RangeHoodsService.java
@@ -15,9 +15,8 @@ import uk.gov.beis.els.service.TemplatePopulator;
 public class RangeHoodsService {
 
   public static final LegislationCategory LEGISLATION_CATEGORY_CURRENT = LegislationCategory.of(
-      RatingClassRange.of(RatingClass.APPP, RatingClass.D));
-
-  public static final RatingClassRange SECONDARY_CLASS_RANGE = RatingClassRange.of(RatingClass.A, RatingClass.G);
+      RatingClassRange.of(RatingClass.APPP, RatingClass.D),
+      RatingClassRange.of(RatingClass.A, RatingClass.G));
 
   private final TemplateParserService templateParserService;
 


### PR DESCRIPTION
Added Range hood API points

- Updated `OpenApiPropertyCustomiser` to take in the secondary `RatingRange` from the current legislation
  - Currently `processLegislationCategoryValues` tries to get the rating ranges from a legislationCategory's primary rating range by default
- Added `RangeHoodsApiController` and `RangeHoodsInternetLabelApiForm`
- Updated `RangeHoodsForm`