### PR TITLE
Feature/ELG-11/APIs for lamps and light sources

### DIFF
--- a/src/main/java/uk/gov/beis/els/api/categories/lamps/LampsApiController.java
+++ b/src/main/java/uk/gov/beis/els/api/categories/lamps/LampsApiController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.beis.els.categories.internetlabelling.service.InternetLabelService;
+import uk.gov.beis.els.categories.lamps.model.LampsFormNoSupplierModel;
 import uk.gov.beis.els.categories.lamps.model.LampsFormNoSupplierModelConsumption;
 import uk.gov.beis.els.categories.lamps.service.LampsService;
 import uk.gov.beis.els.service.DocumentRendererService;
@@ -37,6 +38,16 @@ public class LampsApiController {
   )
   @PostMapping("/energy-rating-only/energy-label")
   public Object lampsExNameModelConsumption(@RequestBody @Valid LampsFormNoSupplierModelConsumption form) {
+    return documentRendererService.processPdfApiResponse(
+        lampsService.generateHtml(form, LampsService.LEGISLATION_CATEGORY_PRE_SEPTEMBER_2021));
+  }
+
+  @Operation(
+      summary = "Create an energy label for lamps with energy rating and consumption only",
+      description = "The label should be at least 36mm x 68mm when attached to packaging. If it doesn’t fit, you can reduce the height by up to 60 percent. It can be full colour or black and white."
+  )
+  @PostMapping("/energy-rating-and-consumption-only/energy-label")
+  public Object LampsExNameModel(@RequestBody @Valid LampsFormNoSupplierModel form) {
     return documentRendererService.processPdfApiResponse(
         lampsService.generateHtml(form, LampsService.LEGISLATION_CATEGORY_PRE_SEPTEMBER_2021));
   }

--- a/src/main/java/uk/gov/beis/els/api/categories/lamps/LampsApiController.java
+++ b/src/main/java/uk/gov/beis/els/api/categories/lamps/LampsApiController.java
@@ -35,7 +35,7 @@ public class LampsApiController {
   }
 
   @Operation(
-      summary = "Create an energy label for lamps with energy rating only",
+      summary = "Lamps with energy rating only: Energy label",
       description = "The label should be at least 36mm x 62mm when attached to packaging. If it doesn’t fit, you can reduce the height by up to 60 percent. It can be full colour or black and white."
   )
   @PostMapping("/energy-rating-only/energy-label")
@@ -45,7 +45,7 @@ public class LampsApiController {
   }
 
   @Operation(
-      summary = "Create an energy label for lamps with energy rating and consumption only",
+      summary = "Lamps with energy rating and consumption only: Energy label",
       description = "The label should be at least 36mm x 68mm when attached to packaging. If it doesn’t fit, you can reduce the height by up to 60 percent. It can be full colour or black and white."
   )
   @PostMapping("/energy-rating-and-consumption-only/energy-label")
@@ -55,7 +55,7 @@ public class LampsApiController {
   }
 
   @Operation(
-      summary = "Create an old style energy label for lamps with all fields",
+      summary = "Create an old style energy label including the energy rating, weighted energy consumption, supplier's name and model identification code",
       description = "If the product was first placed on the market on or after 1 October 2021, or hasn't been placed on the market yet, you must use the new rescaled energy label." +
           "\nProducts placed on the market before 1 October 2021 can continue to use the old style label until 31 March 2023." +
           "\nOld-style labels must usually be at least 36mm x 75mm when attached to packaging. You can scale down the label if no side of the packaging is large enough to contain the label, or if the label would cover more than 50% of the surface area of the largest side. You must only scale down the label enough to meet these conditions, and the label must never be less than 14.4mm x 30mm."
@@ -63,30 +63,43 @@ public class LampsApiController {
   @PostMapping("/all-fields/old-style/energy-label")
   public Object lampsAllFieldsOldStyle(@RequestBody @Valid LampsPreSeptember2021ApiForm form) {
     return documentRendererService.processPdfApiResponse(
-        lampsService.generateHtml(form, LampsService.LEGISLATION_CATEGORY_PRE_SEPTEMBER_2021));
+        lampsService.generateHtml(lampsService.toStandardLampsForm(form),
+            LampsService.LEGISLATION_CATEGORY_PRE_SEPTEMBER_2021)
+    );
   }
 
   @Operation(
-      summary = "Create a new style energy label for lamps with all fields",
+      summary = "Create a new style energy label including the energy rating, weighted energy consumption, supplier's name and model identification code",
       description = "New-style rescaled labels must be at least 36mm x 72mm, or 20mm x 54mm for the small version of the label."
   )
   @PostMapping("/all-fields/new-style/energy-label")
   public Object lampsAllFields(@RequestBody @Valid LampsPostSeptember2021ApiForm form) {
     return documentRendererService.processPdfApiResponse(
-        lampsService.generateHtml(form, LampsService.LEGISLATION_CATEGORY_POST_SEPTEMBER_2021));
+        lampsService.generateHtml(lampsService.toStandardLampsForm(form),
+            LampsService.LEGISLATION_CATEGORY_POST_SEPTEMBER_2021)
+    );
   }
 
-  @Operation(summary = "Lamps and light sources arrow image")
-  @PostMapping("/arrow-image")
-  public Object lampsInternetLabel(@RequestBody @Valid LampsArrowImageApiForm form) {
+  @Operation(summary = "Lamps and light sources: New style arrow image")
+  @PostMapping("/new-style/arrow-image")
+  public Object lampsNewStyleInternetLabel(@RequestBody @Valid LampsNewStyleInternetLabelApiForm form) {
     return documentRendererService.processImageApiResponse(
         internetLabelService.generateInternetLabel(form, form.getEfficiencyRating(),
             LampsService.LEGISLATION_CATEGORY_POST_SEPTEMBER_2021, ProductMetadata.LAMPS_FULL)
     );
   }
 
+  @Operation(summary = "Lamps and light sources: Old style arrow image")
+  @PostMapping("/old-style/arrow-image")
+  public Object lampsOldStyleInternetLabel(@RequestBody @Valid LampsOldStyleInternetLabelApiForm form) {
+    return documentRendererService.processImageApiResponse(
+        internetLabelService.generateInternetLabel(form, form.getEfficiencyRating(),
+            LampsService.LEGISLATION_CATEGORY_PRE_SEPTEMBER_2021, ProductMetadata.LAMPS_FULL)
+    );
+  }
+
   @Operation(
-      summary = "Energy rating arrow for light source packaging",
+      summary = "light source packaging: Energy rating arrow",
       description = "This arrow must only be used on products which include a new-style rescaled energy label. The arrow must be shown on the front of the packaging if the energy label isn't on the front. It must be clearly visible and legible. You don't need to include this arrow on the packaging if the energy label is on the front."
   )
   @PostMapping("/new-style/packaging-arrow")

--- a/src/main/java/uk/gov/beis/els/api/categories/lamps/LampsApiController.java
+++ b/src/main/java/uk/gov/beis/els/api/categories/lamps/LampsApiController.java
@@ -1,0 +1,43 @@
+package uk.gov.beis.els.api.categories.lamps;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import javax.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import uk.gov.beis.els.categories.internetlabelling.service.InternetLabelService;
+import uk.gov.beis.els.categories.lamps.model.LampsFormNoSupplierModelConsumption;
+import uk.gov.beis.els.categories.lamps.service.LampsService;
+import uk.gov.beis.els.service.DocumentRendererService;
+
+@RestController
+@RequestMapping("${api.v1.base_path}/lamps")
+@Tag(name = "Lamps and light sources")
+public class LampsApiController {
+
+  private final LampsService lampsService;
+  private final InternetLabelService internetLabelService;
+  private final DocumentRendererService documentRendererService;
+
+  @Autowired
+  public LampsApiController(LampsService lampsService,
+                            InternetLabelService internetLabelService,
+                            DocumentRendererService documentRendererService) {
+    this.lampsService = lampsService;
+    this.internetLabelService = internetLabelService;
+    this.documentRendererService = documentRendererService;
+  }
+
+  @Operation(
+      summary = "Create an energy label for lamps with energy rating only",
+      description = "The label should be at least 36mm x 62mm when attached to packaging. If it doesn’t fit, you can reduce the height by up to 60 percent. It can be full colour or black and white."
+  )
+  @PostMapping("/energy-rating-only/energy-label")
+  public Object lampsExNameModelConsumption(@RequestBody @Valid LampsFormNoSupplierModelConsumption form) {
+    return documentRendererService.processPdfApiResponse(
+        lampsService.generateHtml(form, LampsService.LEGISLATION_CATEGORY_PRE_SEPTEMBER_2021));
+  }
+}

--- a/src/main/java/uk/gov/beis/els/api/categories/lamps/LampsApiController.java
+++ b/src/main/java/uk/gov/beis/els/api/categories/lamps/LampsApiController.java
@@ -47,7 +47,19 @@ public class LampsApiController {
       description = "The label should be at least 36mm x 68mm when attached to packaging. If it doesn’t fit, you can reduce the height by up to 60 percent. It can be full colour or black and white."
   )
   @PostMapping("/energy-rating-and-consumption-only/energy-label")
-  public Object LampsExNameModel(@RequestBody @Valid LampsFormNoSupplierModel form) {
+  public Object lampsExNameModel(@RequestBody @Valid LampsFormNoSupplierModel form) {
+    return documentRendererService.processPdfApiResponse(
+        lampsService.generateHtml(form, LampsService.LEGISLATION_CATEGORY_PRE_SEPTEMBER_2021));
+  }
+
+  @Operation(
+      summary = "Create an old style energy label for lamps with all fields",
+      description = "If the product was first placed on the market on or after 1 October 2021, or hasn't been placed on the market yet, you must use the new rescaled energy label." +
+          "\nProducts placed on the market before 1 October 2021 can continue to use the old style label until 31 March 2023." +
+          "\nOld-style labels must usually be at least 36mm x 75mm when attached to packaging. You can scale down the label if no side of the packaging is large enough to contain the label, or if the label would cover more than 50% of the surface area of the largest side. You must only scale down the label enough to meet these conditions, and the label must never be less than 14.4mm x 30mm."
+  )
+  @PostMapping("/all-fields/old-style/energy-label")
+  public Object lampsAllFieldsOldStyle(@RequestBody @Valid LampsPreSeptember2021ApiForm form) {
     return documentRendererService.processPdfApiResponse(
         lampsService.generateHtml(form, LampsService.LEGISLATION_CATEGORY_PRE_SEPTEMBER_2021));
   }

--- a/src/main/java/uk/gov/beis/els/api/categories/lamps/LampsApiController.java
+++ b/src/main/java/uk/gov/beis/els/api/categories/lamps/LampsApiController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 import uk.gov.beis.els.categories.internetlabelling.service.InternetLabelService;
 import uk.gov.beis.els.categories.lamps.model.LampsFormNoSupplierModel;
 import uk.gov.beis.els.categories.lamps.model.LampsFormNoSupplierModelConsumption;
+import uk.gov.beis.els.categories.lamps.model.LampsFormPackagingArrow;
 import uk.gov.beis.els.categories.lamps.service.LampsService;
 import uk.gov.beis.els.model.ProductMetadata;
 import uk.gov.beis.els.service.DocumentRendererService;
@@ -82,5 +83,12 @@ public class LampsApiController {
         internetLabelService.generateInternetLabel(form, form.getEfficiencyRating(),
             LampsService.LEGISLATION_CATEGORY_POST_SEPTEMBER_2021, ProductMetadata.LAMPS_FULL)
     );
+  }
+
+  @Operation(summary = "Energy rating arrow for light source packaging")
+  @PostMapping("/new-style/packaging-arrow")
+  public Object packagingArrow(@RequestBody @Valid LampsFormPackagingArrow form) {
+    return documentRendererService.processPdfApiResponse(
+        lampsService.generateHtml(form, LampsService.LEGISLATION_CATEGORY_POST_SEPTEMBER_2021));
   }
 }

--- a/src/main/java/uk/gov/beis/els/api/categories/lamps/LampsApiController.java
+++ b/src/main/java/uk/gov/beis/els/api/categories/lamps/LampsApiController.java
@@ -12,6 +12,7 @@ import uk.gov.beis.els.categories.internetlabelling.service.InternetLabelService
 import uk.gov.beis.els.categories.lamps.model.LampsFormNoSupplierModel;
 import uk.gov.beis.els.categories.lamps.model.LampsFormNoSupplierModelConsumption;
 import uk.gov.beis.els.categories.lamps.service.LampsService;
+import uk.gov.beis.els.model.ProductMetadata;
 import uk.gov.beis.els.service.DocumentRendererService;
 
 @RestController
@@ -72,5 +73,14 @@ public class LampsApiController {
   public Object lampsAllFields(@RequestBody @Valid LampsPostSeptember2021ApiForm form) {
     return documentRendererService.processPdfApiResponse(
         lampsService.generateHtml(form, LampsService.LEGISLATION_CATEGORY_POST_SEPTEMBER_2021));
+  }
+
+  @Operation(summary = "Lamps and light sources arrow image")
+  @PostMapping("/arrow-image")
+  public Object lampsInternetLabel(@RequestBody @Valid LampsArrowImageApiForm form) {
+    return documentRendererService.processImageApiResponse(
+        internetLabelService.generateInternetLabel(form, form.getEfficiencyRating(),
+            LampsService.LEGISLATION_CATEGORY_POST_SEPTEMBER_2021, ProductMetadata.LAMPS_FULL)
+    );
   }
 }

--- a/src/main/java/uk/gov/beis/els/api/categories/lamps/LampsApiController.java
+++ b/src/main/java/uk/gov/beis/els/api/categories/lamps/LampsApiController.java
@@ -85,7 +85,10 @@ public class LampsApiController {
     );
   }
 
-  @Operation(summary = "Energy rating arrow for light source packaging")
+  @Operation(
+      summary = "Energy rating arrow for light source packaging",
+      description = "This arrow must only be used on products which include a new-style rescaled energy label. The arrow must be shown on the front of the packaging if the energy label isn't on the front. It must be clearly visible and legible. You don't need to include this arrow on the packaging if the energy label is on the front."
+  )
   @PostMapping("/new-style/packaging-arrow")
   public Object packagingArrow(@RequestBody @Valid LampsFormPackagingArrow form) {
     return documentRendererService.processPdfApiResponse(

--- a/src/main/java/uk/gov/beis/els/api/categories/lamps/LampsApiController.java
+++ b/src/main/java/uk/gov/beis/els/api/categories/lamps/LampsApiController.java
@@ -63,4 +63,14 @@ public class LampsApiController {
     return documentRendererService.processPdfApiResponse(
         lampsService.generateHtml(form, LampsService.LEGISLATION_CATEGORY_PRE_SEPTEMBER_2021));
   }
+
+  @Operation(
+      summary = "Create a new style energy label for lamps with all fields",
+      description = "New-style rescaled labels must be at least 36mm x 72mm, or 20mm x 54mm for the small version of the label."
+  )
+  @PostMapping("/all-fields/new-style/energy-label")
+  public Object lampsAllFields(@RequestBody @Valid LampsPostSeptember2021ApiForm form) {
+    return documentRendererService.processPdfApiResponse(
+        lampsService.generateHtml(form, LampsService.LEGISLATION_CATEGORY_POST_SEPTEMBER_2021));
+  }
 }

--- a/src/main/java/uk/gov/beis/els/api/categories/lamps/LampsArrowImageApiForm.java
+++ b/src/main/java/uk/gov/beis/els/api/categories/lamps/LampsArrowImageApiForm.java
@@ -1,0 +1,27 @@
+package uk.gov.beis.els.api.categories.lamps;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import javax.validation.constraints.NotBlank;
+import uk.gov.beis.els.api.common.ApiValuesFromLegislationCategory;
+import uk.gov.beis.els.api.common.RescaledInternetLabelApiForm;
+import uk.gov.beis.els.categories.lamps.service.LampsService;
+
+@Schema(name = "Lamps and light sources arrow image")
+public class LampsArrowImageApiForm extends RescaledInternetLabelApiForm {
+
+  @NotBlank(message = "Select an energy efficiency class")
+  @Schema(description = "Energy efficiency class of the application")
+  @ApiValuesFromLegislationCategory(
+      serviceClass = LampsService.class,
+      legislationCategoryFieldName = "LEGISLATION_CATEGORY_POST_SEPTEMBER_2021"
+  )
+  private String efficiencyRating;
+
+  public String getEfficiencyRating() {
+    return efficiencyRating;
+  }
+
+  public void setEfficiencyRating(String efficiencyRating) {
+    this.efficiencyRating = efficiencyRating;
+  }
+}

--- a/src/main/java/uk/gov/beis/els/api/categories/lamps/LampsNewStyleInternetLabelApiForm.java
+++ b/src/main/java/uk/gov/beis/els/api/categories/lamps/LampsNewStyleInternetLabelApiForm.java
@@ -6,8 +6,8 @@ import uk.gov.beis.els.api.common.ApiValuesFromLegislationCategory;
 import uk.gov.beis.els.api.common.RescaledInternetLabelApiForm;
 import uk.gov.beis.els.categories.lamps.service.LampsService;
 
-@Schema(name = "Lamps and light sources arrow image")
-public class LampsArrowImageApiForm extends RescaledInternetLabelApiForm {
+@Schema(name = "Lamps and light sources new style arrow image")
+public class LampsNewStyleInternetLabelApiForm extends RescaledInternetLabelApiForm {
 
   @NotBlank(message = "Select an energy efficiency class")
   @Schema(description = "Energy efficiency class of the application")

--- a/src/main/java/uk/gov/beis/els/api/categories/lamps/LampsOldStyleInternetLabelApiForm.java
+++ b/src/main/java/uk/gov/beis/els/api/categories/lamps/LampsOldStyleInternetLabelApiForm.java
@@ -1,0 +1,27 @@
+package uk.gov.beis.els.api.categories.lamps;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import javax.validation.constraints.NotBlank;
+import uk.gov.beis.els.api.common.ApiValuesFromLegislationCategory;
+import uk.gov.beis.els.api.common.BaseInternetLabelApiForm;
+import uk.gov.beis.els.categories.lamps.service.LampsService;
+
+@Schema(name = "Lamps and light sources old style arrow image")
+public class LampsOldStyleInternetLabelApiForm extends BaseInternetLabelApiForm {
+
+  @NotBlank(message = "Select an energy efficiency class")
+  @Schema(description = "Energy efficiency class of the application")
+  @ApiValuesFromLegislationCategory(
+      serviceClass = LampsService.class,
+      legislationCategoryFieldName = "LEGISLATION_CATEGORY_PRE_SEPTEMBER_2021"
+  )
+  private String efficiencyRating;
+
+  public String getEfficiencyRating() {
+    return efficiencyRating;
+  }
+
+  public void setEfficiencyRating(String efficiencyRating) {
+    this.efficiencyRating = efficiencyRating;
+  }
+}

--- a/src/main/java/uk/gov/beis/els/api/categories/lamps/LampsPostSeptember2021ApiForm.java
+++ b/src/main/java/uk/gov/beis/els/api/categories/lamps/LampsPostSeptember2021ApiForm.java
@@ -1,0 +1,90 @@
+package uk.gov.beis.els.api.categories.lamps;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import javax.validation.constraints.Digits;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+import uk.gov.beis.els.api.common.ApiValuesFromEnum;
+import uk.gov.beis.els.api.common.ApiValuesFromLegislationCategory;
+import uk.gov.beis.els.categories.common.StandardTemplateForm50Char;
+import uk.gov.beis.els.categories.lamps.model.TemplateColour;
+import uk.gov.beis.els.categories.lamps.model.TemplateSize;
+import uk.gov.beis.els.categories.lamps.service.LampsService;
+
+@Schema(name = "Lamps and light sources new style energy label")
+public class LampsPostSeptember2021ApiForm extends StandardTemplateForm50Char {
+
+  @NotBlank(message = "Select an energy efficiency class")
+  @Schema(description = "Energy efficiency class of the application")
+  @ApiValuesFromLegislationCategory(
+      serviceClass = LampsService.class,
+      legislationCategoryFieldName = "LEGISLATION_CATEGORY_POST_SEPTEMBER_2021"
+  )
+  private String efficiencyRating;
+
+  @Digits(integer = 4, fraction = 0, message = "Enter an energy consumption, up to 4 digits long")
+  @Schema(
+      type = "integer",
+      description = "Weighted energy consumption (EC) in kWh per 1000 hours, rounded up to the nearest integer"
+  )
+  @NotNull
+  private String energyConsumption;
+
+  @NotBlank(message = "Select the size of label you need to create")
+  @ApiValuesFromEnum(TemplateSize.class)
+  @Schema(description = "What size of label do you need to create? You must only use the small label on packaging less than 36mm wide")
+  private String templateSize;
+
+  @NotBlank(message = "Select whether the label should be in colour or black and white")
+  @ApiValuesFromEnum(TemplateColour.class)
+  @Schema(description = "Should the label be in colour or black and white?")
+  private String templateColour;
+
+  @Pattern(regexp = "^(https|http)://([a-zA-Z0-9\\-]+)\\.[a-zA-Z0-9]+.*",
+      message = "Enter a link to the product information sheet. Links must start with http:// or https:// and contain at least one dot (.) character"
+  )
+  @Schema(description = "Enter a link to the product information sheet. Links must start with http:// or https:// and contain at least one dot (.) character")
+  @NotNull
+  private String qrCodeUrl;
+
+  public String getEfficiencyRating() {
+    return efficiencyRating;
+  }
+
+  public void setEfficiencyRating(String efficiencyRating) {
+    this.efficiencyRating = efficiencyRating;
+  }
+
+  public String getEnergyConsumption() {
+    return energyConsumption;
+  }
+
+  public void setEnergyConsumption(String energyConsumption) {
+    this.energyConsumption = energyConsumption;
+  }
+
+  public String getTemplateSize() {
+    return templateSize;
+  }
+
+  public void setTemplateSize(String templateSize) {
+    this.templateSize = templateSize;
+  }
+
+  public String getTemplateColour() {
+    return templateColour;
+  }
+
+  public void setTemplateColour(String templateColour) {
+    this.templateColour = templateColour;
+  }
+
+  public String getQrCodeUrl() {
+    return qrCodeUrl;
+  }
+
+  public void setQrCodeUrl(String qrCodeUrl) {
+    this.qrCodeUrl = qrCodeUrl;
+  }
+}

--- a/src/main/java/uk/gov/beis/els/api/categories/lamps/LampsPreSeptember2021ApiForm.java
+++ b/src/main/java/uk/gov/beis/els/api/categories/lamps/LampsPreSeptember2021ApiForm.java
@@ -1,0 +1,45 @@
+package uk.gov.beis.els.api.categories.lamps;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import javax.validation.constraints.Digits;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import uk.gov.beis.els.api.common.ApiValuesFromLegislationCategory;
+import uk.gov.beis.els.categories.common.StandardTemplateForm50Char;
+import uk.gov.beis.els.categories.lamps.service.LampsService;
+
+@Schema(name = "Lamps and light sources old style energy label")
+public class LampsPreSeptember2021ApiForm extends StandardTemplateForm50Char {
+
+  @NotBlank(message = "Select an energy efficiency class")
+  @Schema(description = "Energy efficiency class of the application")
+  @ApiValuesFromLegislationCategory(
+      serviceClass = LampsService.class,
+      legislationCategoryFieldName = "LEGISLATION_CATEGORY_PRE_SEPTEMBER_2021"
+  )
+  private String efficiencyRating;
+
+  @Digits(integer = 4, fraction = 0, message = "Enter an energy consumption, up to 4 digits long")
+  @Schema(
+      type = "integer",
+      description = "Weighted energy consumption (EC) in kWh per 1000 hours, rounded up to the nearest integer"
+  )
+  @NotNull
+  private String energyConsumption;
+
+  public String getEfficiencyRating() {
+    return efficiencyRating;
+  }
+
+  public void setEfficiencyRating(String efficiencyRating) {
+    this.efficiencyRating = efficiencyRating;
+  }
+
+  public String getEnergyConsumption() {
+    return energyConsumption;
+  }
+
+  public void setEnergyConsumption(String energyConsumption) {
+    this.energyConsumption = energyConsumption;
+  }
+}

--- a/src/main/java/uk/gov/beis/els/categories/lamps/model/LampsFormNoSupplierModel.java
+++ b/src/main/java/uk/gov/beis/els/categories/lamps/model/LampsFormNoSupplierModel.java
@@ -1,28 +1,41 @@
 package uk.gov.beis.els.categories.lamps.model;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import javax.validation.constraints.Digits;
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import javax.validation.groups.Default;
+import uk.gov.beis.els.api.common.ApiValuesFromEnum;
+import uk.gov.beis.els.api.common.ApiValuesFromLegislationCategory;
 import uk.gov.beis.els.categories.internetlabelling.model.InternetLabellingForm;
 import uk.gov.beis.els.categories.internetlabelling.model.InternetLabellingGroup;
+import uk.gov.beis.els.categories.lamps.service.LampsService;
 import uk.gov.beis.els.model.meta.DualModeField;
 import uk.gov.beis.els.model.meta.FieldPrompt;
 import uk.gov.beis.els.model.meta.StaticProductText;
 
+@Schema(name = "Lamps energy label with energy rating and consumption only")
 @StaticProductText("The label should be at least 36mm x 68mm when attached to packaging. If it doesn’t fit, you can reduce the height by up to 60 percent. It can be full colour or black and white.")
 public class LampsFormNoSupplierModel extends InternetLabellingForm {
 
   @FieldPrompt("Energy efficiency class of the application")
   @NotBlank(message = "Select an energy efficiency class", groups = {Default.class, InternetLabellingGroup.class})
   @DualModeField
+  @ApiValuesFromLegislationCategory(
+      serviceClass = LampsService.class,
+      legislationCategoryFieldName = "LEGISLATION_CATEGORY_PRE_SEPTEMBER_2021"
+  )
   private String efficiencyRating;
 
   @FieldPrompt("Weighted energy consumption (EC) in kWh per 1000 hours, rounded up to the nearest integer")
   @Digits(integer = 4, fraction = 0, message = "Enter an energy consumption, up to 4 digits long")
+  @Schema(type = "integer")
+  @NotNull
   private String energyConsumption;
 
   @FieldPrompt("Should the label be in colour or black and white?")
   @NotBlank(message = "Select whether the label should be in colour or black and white")
+  @ApiValuesFromEnum(TemplateColour.class)
   private String templateColour;
 
   public String getEfficiencyRating() {

--- a/src/main/java/uk/gov/beis/els/categories/lamps/model/LampsFormNoSupplierModelConsumption.java
+++ b/src/main/java/uk/gov/beis/els/categories/lamps/model/LampsFormNoSupplierModelConsumption.java
@@ -1,23 +1,33 @@
 package uk.gov.beis.els.categories.lamps.model;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import javax.validation.constraints.NotBlank;
 import javax.validation.groups.Default;
+import uk.gov.beis.els.api.common.ApiValuesFromEnum;
+import uk.gov.beis.els.api.common.ApiValuesFromLegislationCategory;
 import uk.gov.beis.els.categories.internetlabelling.model.InternetLabellingForm;
 import uk.gov.beis.els.categories.internetlabelling.model.InternetLabellingGroup;
+import uk.gov.beis.els.categories.lamps.service.LampsService;
 import uk.gov.beis.els.model.meta.DualModeField;
 import uk.gov.beis.els.model.meta.FieldPrompt;
 import uk.gov.beis.els.model.meta.StaticProductText;
 
+@Schema(name = "Lamps energy label with energy rating only")
 @StaticProductText("The label should be at least 36mm x 62mm when attached to packaging. If it doesn’t fit, you can reduce the height by up to 60 percent. It can be full colour or black and white.")
 public class LampsFormNoSupplierModelConsumption extends InternetLabellingForm {
 
   @FieldPrompt("Energy efficiency class of the application")
   @NotBlank(message = "Select an energy efficiency class", groups = {Default.class, InternetLabellingGroup.class})
   @DualModeField
+  @ApiValuesFromLegislationCategory(
+      serviceClass = LampsService.class,
+      legislationCategoryFieldName = "LEGISLATION_CATEGORY_PRE_SEPTEMBER_2021"
+  )
   private String efficiencyRating;
 
   @FieldPrompt("Should the label be in colour or black and white?")
   @NotBlank(message = "Select whether the label should be in colour or black and white")
+  @ApiValuesFromEnum(TemplateColour.class)
   private String templateColour;
 
   public String getEfficiencyRating() {

--- a/src/main/java/uk/gov/beis/els/categories/lamps/model/LampsFormPackagingArrow.java
+++ b/src/main/java/uk/gov/beis/els/categories/lamps/model/LampsFormPackagingArrow.java
@@ -1,25 +1,36 @@
 package uk.gov.beis.els.categories.lamps.model;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import javax.validation.constraints.NotBlank;
 import javax.validation.groups.Default;
+import uk.gov.beis.els.api.common.ApiValuesFromEnum;
+import uk.gov.beis.els.api.common.ApiValuesFromLegislationCategory;
 import uk.gov.beis.els.categories.common.AnalyticsForm;
 import uk.gov.beis.els.categories.internetlabelling.model.InternetLabellingGroup;
+import uk.gov.beis.els.categories.lamps.service.LampsService;
 import uk.gov.beis.els.model.meta.FieldPrompt;
 import uk.gov.beis.els.model.meta.StaticProductText;
 
+@Schema(name = "Energy rating arrow for light source packaging")
 @StaticProductText("The arrow must be shown on the front of the packaging if the energy label isn't on the front. It must be clearly visible and legible. You don't need to include this arrow on the packaging if the energy label is on the front.")
 public class LampsFormPackagingArrow extends AnalyticsForm {
 
   @FieldPrompt("Energy efficiency class of the application")
   @NotBlank(message = "Select an energy efficiency class", groups = {Default.class, InternetLabellingGroup.class})
+  @ApiValuesFromLegislationCategory(
+      serviceClass = LampsService.class,
+      legislationCategoryFieldName = "LEGISLATION_CATEGORY_POST_SEPTEMBER_2021"
+  )
   private String efficiencyRating;
 
   @FieldPrompt(value = "Should the arrow be in colour or black and white?", hintText = "You must only use a black and white arrow if all other information on the packaging, including graphics, is printed in black and white")
   @NotBlank(message = "Select whether the arrow be in colour or black and white")
+  @ApiValuesFromEnum(TemplateColour.class)
   private String templateColour;
 
   @FieldPrompt("Arrow direction")
   @NotBlank(message = "Select an arrow direction")
+  @ApiValuesFromEnum(LightSourceArrowOrientation.class)
   private String labelOrientation;
 
   public String getEfficiencyRating() {

--- a/src/main/java/uk/gov/beis/els/categories/lamps/service/LampsService.java
+++ b/src/main/java/uk/gov/beis/els/categories/lamps/service/LampsService.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableList;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import uk.gov.beis.els.api.categories.lamps.LampsPostSeptember2021ApiForm;
 import uk.gov.beis.els.api.categories.lamps.LampsPreSeptember2021ApiForm;
 import uk.gov.beis.els.categories.common.ProcessedEnergyLabelDocument;
 import uk.gov.beis.els.categories.lamps.model.LampsForm;
@@ -148,6 +149,36 @@ public class LampsService {
         .setCondensingMultilineText("supplier", form.getSupplierName())
         .setCondensingMultilineText("model", form.getModelName()).setRatingArrow("rating",
             RatingClass.valueOf(form.getEfficiencyRating()), legislationCategory.getPrimaryRatingRange())
+        .setText("kwh", form.getEnergyConsumption())
+        .asProcessedEnergyLabel(ProductMetadata.LAMPS_FULL, form);
+  }
+
+  public ProcessedEnergyLabelDocument generateHtml(LampsPostSeptember2021ApiForm form,
+                                                   LegislationCategory legislationCategory) {
+    String templatePath;
+    TemplateColour templateColour = TemplateColour.valueOf(form.getTemplateColour());
+    TemplateSize templateSize = TemplateSize.valueOf(form.getTemplateSize());
+
+    if (templateSize == TemplateSize.STANDARD) {
+      if (templateColour == TemplateColour.COLOUR) {
+        templatePath = "labels/lamps-light-sources/light-source-2021.svg";
+      } else {
+        templatePath = "labels/lamps-light-sources/light-source-bw-2021.svg";
+      }
+    } else {
+      if (templateColour == TemplateColour.COLOUR) {
+        templatePath = "labels/lamps-light-sources/light-source-small-2021.svg";
+      } else {
+        templatePath = "labels/lamps-light-sources/light-source-small-bw-2021.svg";
+      }
+    }
+
+    return new TemplatePopulator(templateParserService.parseTemplate(templatePath))
+        .setCondensingText("supplier", form.getSupplierName())
+        .setCondensingText("model", form.getModelName())
+        .setQrCode(form.getQrCodeUrl())
+        .setRatingArrow("rating", RatingClass.valueOf(form.getEfficiencyRating()),
+            legislationCategory.getPrimaryRatingRange())
         .setText("kwh", form.getEnergyConsumption())
         .asProcessedEnergyLabel(ProductMetadata.LAMPS_FULL, form);
   }

--- a/src/main/java/uk/gov/beis/els/categories/lamps/service/LampsService.java
+++ b/src/main/java/uk/gov/beis/els/categories/lamps/service/LampsService.java
@@ -145,6 +145,7 @@ public class LampsService {
 
   public LampsForm toStandardLampsForm(LampsPreSeptember2021ApiForm form){
     LampsForm lampsForm = new LampsForm();
+    lampsForm.setApplicableLegislation(LEGISLATION_CATEGORY_PRE_SEPTEMBER_2021.getId());
     lampsForm.setEfficiencyRating(form.getEfficiencyRating());
     lampsForm.setEnergyConsumption(form.getEnergyConsumption());
     lampsForm.setSupplierName(form.getSupplierName());
@@ -154,6 +155,7 @@ public class LampsService {
 
   public LampsForm toStandardLampsForm(LampsPostSeptember2021ApiForm form) {
     LampsForm lampsForm = new LampsForm();
+    lampsForm.setApplicableLegislation(LEGISLATION_CATEGORY_POST_SEPTEMBER_2021.getId());
     lampsForm.setEfficiencyRating(form.getEfficiencyRating());
     lampsForm.setEnergyConsumption(form.getEnergyConsumption());
     lampsForm.setTemplateSize(form.getTemplateSize());

--- a/src/main/java/uk/gov/beis/els/categories/lamps/service/LampsService.java
+++ b/src/main/java/uk/gov/beis/els/categories/lamps/service/LampsService.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableList;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import uk.gov.beis.els.api.categories.lamps.LampsPreSeptember2021ApiForm;
 import uk.gov.beis.els.categories.common.ProcessedEnergyLabelDocument;
 import uk.gov.beis.els.categories.lamps.model.LampsForm;
 import uk.gov.beis.els.categories.lamps.model.LampsFormNoSupplierModel;
@@ -141,4 +142,13 @@ public class LampsService {
         .asProcessedEnergyLabelLampsPackagingArrow(ProductMetadata.LAMPS_PACKAGING_ARROW, form);
   }
 
+  public ProcessedEnergyLabelDocument generateHtml(LampsPreSeptember2021ApiForm form,
+                                                   LegislationCategory legislationCategory) {
+    return new TemplatePopulator(templateParserService.parseTemplate("labels/lamps-light-sources/lamps.svg"))
+        .setCondensingMultilineText("supplier", form.getSupplierName())
+        .setCondensingMultilineText("model", form.getModelName()).setRatingArrow("rating",
+            RatingClass.valueOf(form.getEfficiencyRating()), legislationCategory.getPrimaryRatingRange())
+        .setText("kwh", form.getEnergyConsumption())
+        .asProcessedEnergyLabel(ProductMetadata.LAMPS_FULL, form);
+  }
 }

--- a/src/main/java/uk/gov/beis/els/categories/lamps/service/LampsService.java
+++ b/src/main/java/uk/gov/beis/els/categories/lamps/service/LampsService.java
@@ -143,43 +143,24 @@ public class LampsService {
         .asProcessedEnergyLabelLampsPackagingArrow(ProductMetadata.LAMPS_PACKAGING_ARROW, form);
   }
 
-  public ProcessedEnergyLabelDocument generateHtml(LampsPreSeptember2021ApiForm form,
-                                                   LegislationCategory legislationCategory) {
-    return new TemplatePopulator(templateParserService.parseTemplate("labels/lamps-light-sources/lamps.svg"))
-        .setCondensingMultilineText("supplier", form.getSupplierName())
-        .setCondensingMultilineText("model", form.getModelName()).setRatingArrow("rating",
-            RatingClass.valueOf(form.getEfficiencyRating()), legislationCategory.getPrimaryRatingRange())
-        .setText("kwh", form.getEnergyConsumption())
-        .asProcessedEnergyLabel(ProductMetadata.LAMPS_FULL, form);
+  public LampsForm toStandardLampsForm(LampsPreSeptember2021ApiForm form){
+    LampsForm lampsForm = new LampsForm();
+    lampsForm.setEfficiencyRating(form.getEfficiencyRating());
+    lampsForm.setEnergyConsumption(form.getEnergyConsumption());
+    lampsForm.setSupplierName(form.getSupplierName());
+    lampsForm.setModelName(form.getModelName());
+    return lampsForm;
   }
 
-  public ProcessedEnergyLabelDocument generateHtml(LampsPostSeptember2021ApiForm form,
-                                                   LegislationCategory legislationCategory) {
-    String templatePath;
-    TemplateColour templateColour = TemplateColour.valueOf(form.getTemplateColour());
-    TemplateSize templateSize = TemplateSize.valueOf(form.getTemplateSize());
-
-    if (templateSize == TemplateSize.STANDARD) {
-      if (templateColour == TemplateColour.COLOUR) {
-        templatePath = "labels/lamps-light-sources/light-source-2021.svg";
-      } else {
-        templatePath = "labels/lamps-light-sources/light-source-bw-2021.svg";
-      }
-    } else {
-      if (templateColour == TemplateColour.COLOUR) {
-        templatePath = "labels/lamps-light-sources/light-source-small-2021.svg";
-      } else {
-        templatePath = "labels/lamps-light-sources/light-source-small-bw-2021.svg";
-      }
-    }
-
-    return new TemplatePopulator(templateParserService.parseTemplate(templatePath))
-        .setCondensingText("supplier", form.getSupplierName())
-        .setCondensingText("model", form.getModelName())
-        .setQrCode(form.getQrCodeUrl())
-        .setRatingArrow("rating", RatingClass.valueOf(form.getEfficiencyRating()),
-            legislationCategory.getPrimaryRatingRange())
-        .setText("kwh", form.getEnergyConsumption())
-        .asProcessedEnergyLabel(ProductMetadata.LAMPS_FULL, form);
+  public LampsForm toStandardLampsForm(LampsPostSeptember2021ApiForm form) {
+    LampsForm lampsForm = new LampsForm();
+    lampsForm.setEfficiencyRating(form.getEfficiencyRating());
+    lampsForm.setEnergyConsumption(form.getEnergyConsumption());
+    lampsForm.setTemplateSize(form.getTemplateSize());
+    lampsForm.setTemplateColour(form.getTemplateColour());
+    lampsForm.setQrCodeUrl(form.getQrCodeUrl());
+    lampsForm.setSupplierName(form.getSupplierName());
+    lampsForm.setModelName(form.getModelName());
+    return lampsForm;
   }
 }


### PR DESCRIPTION
Agreed to split on new/old style labels. And include old style labels in the API

- /api/v1/lamps/all-fields/old-style/energy-label
- /api/v1/lamps/all-fields/new-style/energy-label
- /api/v1/lamps/energy-rating-and-consumption-only/energy-label
- /api/v1/lamps/energy-rating-only/energy-label
- /api/v1/lamps/new-style/arrow-image
- /api/v1/lamps/old-style/arrow-image
- /api/v1/lamps/new-style/packaging-arrow
