### PR TITLE
API doco design and homepage content

### DIFF
--- a/src/main/java/uk/gov/beis/els/api/categories/airconditioners/AirConditionersApiController.java
+++ b/src/main/java/uk/gov/beis/els/api/categories/airconditioners/AirConditionersApiController.java
@@ -39,7 +39,7 @@ public class AirConditionersApiController {
   }
 
   @Operation(
-      summary = "Create an energy label for a cooling-only ductless air conditioner",
+      summary = "Cooling-only ductless air conditioners: energy label",
       description = "The label must be at least 100mm x 200mm when printed."
   )
   @PostMapping("/non-duct/cooling-only-air-conditioners/energy-label")
@@ -47,7 +47,7 @@ public class AirConditionersApiController {
     return documentRendererService.processPdfApiResponse(airConditionersService.generateHtml(form, AirConditionersService.LEGISLATION_CATEGORY_CURRENT));
   }
 
-  @Operation(summary = "Create an arrow image for a cooling-only ductless air conditioner")
+  @Operation(summary = "Cooling-only ductless air conditioners: arrow image")
   @PostMapping("/non-duct/cooling-only-air-conditioners/arrow-image")
   public Object coolingOnlyDuctlessInternetLabel(@Valid @RequestBody AirConditionersInternetLabelApiForm form) {
     return documentRendererService.processImageApiResponse(
@@ -56,7 +56,7 @@ public class AirConditionersApiController {
   }
 
   @Operation(
-      summary = "Create an energy label for a heating-only ductless air conditioner",
+      summary = "Heating-only ductless air conditioners: energy label",
       description = "The label must be at least 100mm x 200mm when printed."
   )
   @PostMapping("/non-duct/heating-only-air-conditioners/energy-label")
@@ -64,7 +64,7 @@ public class AirConditionersApiController {
     return documentRendererService.processPdfApiResponse(airConditionersService.generateHtml(form, AirConditionersService.LEGISLATION_CATEGORY_CURRENT));
   }
 
-  @Operation(summary = "Create an arrow image for a heating-only ductless air conditioner")
+  @Operation(summary = "Heating-only ductless air conditioners: arrow image")
   @PostMapping("/non-duct/heating-only-air-conditioners/arrow-image")
   public Object heatingOnlyDuctlessInternetLabel(@Valid @RequestBody AirConditionersInternetLabelApiForm form) {
     return documentRendererService.processImageApiResponse(
@@ -73,7 +73,7 @@ public class AirConditionersApiController {
   }
 
   @Operation(
-      summary = "Create an energy label for a reversible ductless air conditioner",
+      summary = "Reversible ductless air conditioners: energy label",
       description = "The label must be at least 120mm x 210mm when printed "
   )
   @PostMapping("/non-duct/reversible-air-conditioners/energy-label")
@@ -81,7 +81,7 @@ public class AirConditionersApiController {
     return documentRendererService.processPdfApiResponse(airConditionersService.generateHtml(form, AirConditionersService.LEGISLATION_CATEGORY_CURRENT));
   }
 
-  @Operation(summary = "Create an arrow image for a reversible ductless air conditioner")
+  @Operation(summary = "Reversible ductless air conditioners: arrow image")
   @PostMapping("/non-duct/reversible-air-conditioners/arrow-image")
   public Object reversibleDuctlessInternetLabel(@Valid @RequestBody AirConditionersInternetLabelApiForm form) {
     return documentRendererService.processImageApiResponse(
@@ -90,7 +90,7 @@ public class AirConditionersApiController {
   }
 
   @Operation(
-      summary = "Create an energy label for a cooling-only single or double duct air conditioner",
+      summary = "Cooling-only single or double duct air conditioners: energy label",
       description = "The label must be at least 100mm x 200mm when printed."
   )
   @PostMapping("/single-or-double-duct/cooling-only-air-conditioners/energy-label")
@@ -98,7 +98,7 @@ public class AirConditionersApiController {
     return documentRendererService.processPdfApiResponse(airConditionersService.generateHtml(form, AirConditionersService.LEGISLATION_CATEGORY_CURRENT));
   }
 
-  @Operation(summary = "Create an arrow image for a cooling-only single or double duct air conditioner")
+  @Operation(summary = "Cooling-only single or double duct air conditioners: arrow image")
   @PostMapping("/single-or-double-duct/cooling-only-air-conditioners/arrow-image")
   public Object coolingOnlyDuctedInternetLabel(@Valid @RequestBody AirConditionersInternetLabelApiForm form) {
     return documentRendererService.processImageApiResponse(
@@ -107,7 +107,7 @@ public class AirConditionersApiController {
   }
 
   @Operation(
-      summary = "Create an energy label for a heating-only single or double duct air conditioner",
+      summary = "Heating-only single or double duct air conditioners: energy label",
       description = "The label must be at least 100mm x 200mm when printed."
   )
   @PostMapping("/single-or-double-duct/heating-only-air-conditioners/energy-label")
@@ -115,7 +115,7 @@ public class AirConditionersApiController {
     return documentRendererService.processPdfApiResponse(airConditionersService.generateHtml(form, AirConditionersService.LEGISLATION_CATEGORY_CURRENT));
   }
 
-  @Operation(summary = "Create an arrow image for a heating-only single or double duct air conditioner")
+  @Operation(summary = "Heating-only single or double duct air conditioners: arrow image")
   @PostMapping("/single-or-double-duct/heating-only-air-conditioners/arrow-image")
   public Object heatingOnlyDuctedInternetLabel(@Valid @RequestBody AirConditionersInternetLabelApiForm form) {
     return documentRendererService.processImageApiResponse(
@@ -124,7 +124,7 @@ public class AirConditionersApiController {
   }
 
   @Operation(
-      summary = "Create an energy label for a reversible single or double duct air conditioner",
+      summary = "Reversible single or double duct air conditioners: energy label",
       description = "The label must be at least 100mm x 200mm when printed."
   )
   @PostMapping("/single-or-double-duct/reversible-air-conditioners/energy-label")
@@ -132,7 +132,7 @@ public class AirConditionersApiController {
     return documentRendererService.processPdfApiResponse(airConditionersService.generateHtml(form, AirConditionersService.LEGISLATION_CATEGORY_CURRENT));
   }
 
-  @Operation(summary = "Create an arrow image for a reversible single or double duct air conditioner")
+  @Operation(summary = "Reversible single or double duct air conditioners: arrow image")
   @PostMapping("/single-or-double-duct/reversible-air-conditioners/arrow-image")
   public Object reversibleDuctedInternetLabel(@Valid @RequestBody AirConditionersInternetLabelApiForm form) {
     return documentRendererService.processImageApiResponse(

--- a/src/main/java/uk/gov/beis/els/api/categories/dishwashers/DishwashersApiController.java
+++ b/src/main/java/uk/gov/beis/els/api/categories/dishwashers/DishwashersApiController.java
@@ -33,7 +33,7 @@ public class DishwashersApiController {
   }
 
   @Operation(
-      summary = "Create an energy label for dishwashers",
+      summary = "Dishwashers: energy label",
       description = "You must attach the label to the front or top of the product so that it’s easy to see. If it's a built-in dishwasher it doesn't have to be attached to the product, but it must still be easy to see. Labels must be at least 96mm x 192mm when printed."
   )
   @PostMapping("/energy-label")
@@ -41,7 +41,7 @@ public class DishwashersApiController {
     return documentRendererService.processPdfApiResponse(dishwashersService.generateHtml(form));
   }
 
-  @Operation(summary = "Create an arrow image for dishwashers")
+  @Operation(summary = "Dishwashers: arrow image")
   @PostMapping("/arrow-image")
   public Object dishwashersInternetLabel(@RequestBody @Valid DishwashersInternetLabelApiForm form) {
     return documentRendererService.processImageApiResponse(

--- a/src/main/java/uk/gov/beis/els/api/categories/domesticovens/DomesticOvensApiController.java
+++ b/src/main/java/uk/gov/beis/els/api/categories/domesticovens/DomesticOvensApiController.java
@@ -32,7 +32,7 @@ public class DomesticOvensApiController {
   }
 
   @Operation(
-    summary = "Create an energy label for an electric oven",
+    summary = "Electric ovens: energy label",
     description = "You must attach the label to the front or top of the product so that it’s easy to see. It must be at least 85mm x 170mm when printed."
   )
   @PostMapping("/electric-ovens/energy-label")
@@ -40,7 +40,7 @@ public class DomesticOvensApiController {
     return documentRendererService.processPdfApiResponse(domesticOvensService.generateHtml(form));
   }
 
-  @Operation(summary = "Create an arrow image for an electric oven")
+  @Operation(summary = "Electric ovens: arrow image")
   @PostMapping("/electric-ovens/arrow-image")
   public Object electricOvensInternetLabel(@Valid @RequestBody DomesticOvenInternetLabelApiForm form) {
     return documentRendererService.processImageApiResponse(
@@ -49,7 +49,7 @@ public class DomesticOvensApiController {
   }
 
   @Operation(
-    summary = "Create an energy label for a gas oven",
+    summary = "Gas ovens: energy label",
     description = "You must attach the label to the front or top of the product so that it’s easy to see. It must be at least 85mm x 170mm when printed."
   )
   @PostMapping("/gas-ovens/energy-label")
@@ -57,7 +57,7 @@ public class DomesticOvensApiController {
     return documentRendererService.processPdfApiResponse(domesticOvensService.generateHtml(form));
   }
 
-  @Operation(summary = "Create an arrow image for a gas oven")
+  @Operation(summary = "Gas ovens: arrow image")
   @PostMapping("/gas-ovens/arrow-image")
   public Object gasOvensInternetLabel(@Valid @RequestBody DomesticOvenInternetLabelApiForm form) {
     return documentRendererService.processImageApiResponse(

--- a/src/main/java/uk/gov/beis/els/api/categories/localspaceheaters/LocalSpaceHeatersApiController.java
+++ b/src/main/java/uk/gov/beis/els/api/categories/localspaceheaters/LocalSpaceHeatersApiController.java
@@ -33,7 +33,7 @@ public class LocalSpaceHeatersApiController {
   }
 
   @Operation(
-      summary = "Create an energy label for local space heaters",
+      summary = "Local space heaters: energy label",
       description = "You must attach the label to the front or top of the product so that it’s easy to see. It must be at least 105mm x 200mm when printed."
   )
   @PostMapping("/energy-label")
@@ -41,7 +41,7 @@ public class LocalSpaceHeatersApiController {
     return documentRendererService.processPdfApiResponse(localSpaceHeatersService.generateHtml(form));
   }
 
-  @Operation(summary = "Create an arrow image for local space heaters")
+  @Operation(summary = "Local space heaters: arrow image")
   @PostMapping("/arrow-image")
   public Object localSpaceHeatersInternetLabel(@RequestBody @Valid LocalSpaceHeatersInternetLabelApiForm form) {
     return documentRendererService.processImageApiResponse(

--- a/src/main/java/uk/gov/beis/els/api/categories/prorefrigeratedcabinets/ProRefrigeratedCabinetsApiController.java
+++ b/src/main/java/uk/gov/beis/els/api/categories/prorefrigeratedcabinets/ProRefrigeratedCabinetsApiController.java
@@ -34,7 +34,7 @@ public class ProRefrigeratedCabinetsApiController {
   }
 
   @Operation(
-      summary = "Create an energy label for professional refrigerated storage cabinets",
+      summary = "Professional refrigerated storage cabinets: energy label",
       description = "You must display the label so that it’s easy to see and clearly related to the product. It must be at least 110mm x 220mm when printed."
   )
   @PostMapping("/energy-label")
@@ -43,7 +43,7 @@ public class ProRefrigeratedCabinetsApiController {
         proRefrigeratedCabinetsService.generateHtml(form, ProRefrigeratedCabinetsService.LEGISLATION_CATEGORY_CURRENT));
   }
 
-  @Operation(summary = "Create an arrow image for professional refrigerated storage cabinets")
+  @Operation(summary = "Professional refrigerated storage cabinets: arrow image")
   @PostMapping("/arrow-image")
   public Object proRefrigeratedCabinetsInternetLabel(
       @RequestBody @Valid ProRefrigeratedCabinetsInternetLabelApiForm form) {

--- a/src/main/java/uk/gov/beis/els/api/categories/rangehoods/RangeHoodsApiController.java
+++ b/src/main/java/uk/gov/beis/els/api/categories/rangehoods/RangeHoodsApiController.java
@@ -33,7 +33,7 @@ public class RangeHoodsApiController {
   }
 
   @Operation(
-      summary = "Create energy label for a range hood",
+      summary = "Range hoods: energy label",
       description = "You must display the label so that it’s easy to see and clearly related to the product. It must be at least 60mm x 120mm when printed."
   )
   @PostMapping("/energy-label")
@@ -42,7 +42,7 @@ public class RangeHoodsApiController {
         rangeHoodsService.generateHtml(form, RangeHoodsService.LEGISLATION_CATEGORY_CURRENT));
   }
 
-  @Operation(summary = "Create an arrow image for a range hood")
+  @Operation(summary = "Range hoods: arrow image")
   @PostMapping("/arrow-image")
   public Object rangeHoodsInternetLabel(@RequestBody @Valid RangeHoodsInternetLabelApiForm form) {
     return documentRendererService.processImageApiResponse(

--- a/src/main/java/uk/gov/beis/els/api/categories/refrigeratingappliances/RefrigeratingAppliancesApiController.java
+++ b/src/main/java/uk/gov/beis/els/api/categories/refrigeratingappliances/RefrigeratingAppliancesApiController.java
@@ -34,7 +34,7 @@ public class RefrigeratingAppliancesApiController {
   }
 
   @Operation(
-      summary = "Create an energy label for household fridges and freezers",
+      summary = "Household fridges and freezers: energy label",
       description = "You must attach the label to the front or top of the product so that it’s easy to see. If it's a built-in appliance it doesn't have to be attached to the product, but it must still be easy to see. Labels must be at least 96mm x 192mm when printed."
   )
   @PostMapping("/household-fridges-and-freezers/energy-label")
@@ -42,7 +42,7 @@ public class RefrigeratingAppliancesApiController {
     return documentRendererService.processPdfApiResponse(refrigeratingAppliancesService.generateHtml(form));
   }
 
-  @Operation(summary = "Create an arrow image for household fridges and freezers")
+  @Operation(summary = "Household fridges and freezers: arrow image")
   @PostMapping("/household-fridges-and-freezers/arrow-image")
   public Object fridgesFreezersInternetLabel(@RequestBody @Valid RefrigeratingAppliancesInternetLapelApiForm form) {
     return documentRendererService.processImageApiResponse(
@@ -54,7 +54,7 @@ public class RefrigeratingAppliancesApiController {
   }
 
   @Operation(
-      summary = "Create an energy label for wine storage appliances",
+      summary = "Wine storage appliances: energy label",
       description = "You must attach the label to the front or top of the product so that it’s easy to see. If it's a built-in appliance it doesn't have to be attached to the product, but it must still be easy to see. Labels must be at least 96mm x 192mm when printed."
   )
   @PostMapping("/wine-storage-appliances/energy-label")
@@ -62,7 +62,7 @@ public class RefrigeratingAppliancesApiController {
     return documentRendererService.processPdfApiResponse(refrigeratingAppliancesService.generateHtml(form));
   }
 
-  @Operation(summary = "Create an arrow image for wine storage appliances")
+  @Operation(summary = "Wine storage appliances: arrow image")
   @PostMapping("/wine-storage-appliances/arrow-image")
   public Object wineStorageAppliancesInternetLabel(@RequestBody @Valid RefrigeratingAppliancesInternetLapelApiForm form) {
     return documentRendererService.processImageApiResponse(

--- a/src/main/java/uk/gov/beis/els/api/categories/refrigeratordirectsales/RefrigeratorsDirectSalesApiController.java
+++ b/src/main/java/uk/gov/beis/els/api/categories/refrigeratordirectsales/RefrigeratorsDirectSalesApiController.java
@@ -37,7 +37,7 @@ public class RefrigeratorsDirectSalesApiController {
   }
 
   @Operation(
-      summary = "Create an energy label for refrigerated vending machines",
+      summary = "Refrigerated vending machines: energy label",
       description = "You must attach the label to the front or top of the product so that it’s easy to see. If it's a built-in appliance it doesn't have to be attached to the product, but it must still be easy to see. It must be at least 96mm x 192mm when printed."
   )
   @PostMapping("/vending-machines/energy-label")
@@ -46,7 +46,7 @@ public class RefrigeratorsDirectSalesApiController {
         RefrigeratorsDirectSalesService.LEGISLATION_CATEGORY_CURRENT));
   }
 
-  @Operation(summary = "Create an arrow image for refrigerated vending machines")
+  @Operation(summary = "Refrigerated vending machines: arrow image")
   @PostMapping("/vending-machines/arrow-image")
   public Object vendingMachinesInternetLabel(@RequestBody @Valid RefrigeratorsDirectSalesInternetLabelApiForm form) {
     return documentRendererService.processImageApiResponse(internetLabelService.generateInternetLabel(form,
@@ -55,7 +55,7 @@ public class RefrigeratorsDirectSalesApiController {
   }
 
   @Operation(
-      summary = "Create an energy label for ice cream freezers",
+      summary = "Ice cream freezers: energy label",
       description = "You must attach the label to the front or top of the product so that it’s easy to see. If it's a built-in appliance it doesn't have to be attached to the product, but it must still be easy to see. It must be at least 96mm x 192mm when printed."
   )
   @PostMapping("/ice-cream-freezers/energy-label")
@@ -64,7 +64,7 @@ public class RefrigeratorsDirectSalesApiController {
         RefrigeratorsDirectSalesService.LEGISLATION_CATEGORY_CURRENT));
   }
 
-  @Operation(summary = "Create an arrow image for ice cream freezers")
+  @Operation(summary = "Ice cream freezers: arrow image")
   @PostMapping("/ice-cream-freezers/arrow-image")
   public Object iceCreamFreezersInternetLabel(@RequestBody @Valid RefrigeratorsDirectSalesInternetLabelApiForm form) {
     return documentRendererService.processImageApiResponse(internetLabelService.generateInternetLabel(form,
@@ -73,7 +73,7 @@ public class RefrigeratorsDirectSalesApiController {
   }
 
   @Operation(
-      summary = "Create an energy label for beverage coolers",
+      summary = "Beverage coolers: energy label",
       description = "You must attach the label to the front or top of the product so that it’s easy to see. If it's a built-in appliance it doesn't have to be attached to the product, but it must still be easy to see. It must be at least 96mm x 192mm when printed."
   )
   @PostMapping("/beverage-coolers/energy-label")
@@ -82,7 +82,7 @@ public class RefrigeratorsDirectSalesApiController {
         RefrigeratorsDirectSalesService.LEGISLATION_CATEGORY_CURRENT));
   }
 
-  @Operation(summary = "Create an arrow image for beverage coolers")
+  @Operation(summary = "Beverage coolers: arrow image")
   @PostMapping("/beverage-coolers/arrow-image")
   public Object beverageCoolersInternetLabel(@RequestBody @Valid RefrigeratorsDirectSalesInternetLabelApiForm form) {
     return documentRendererService.processImageApiResponse(internetLabelService.generateInternetLabel(form,
@@ -91,7 +91,7 @@ public class RefrigeratorsDirectSalesApiController {
   }
 
   @Operation(
-      summary = "Create an energy label for supermarket refrigerator, freezer cabinets or gelato-scooping cabinets",
+      summary = "Supermarket refrigerator or freezer cabinets or gelato-scooping cabinets: energy label",
       description = "You must attach the label to the front or top of the product so that it’s easy to see. If it's a built-in appliance it doesn't have to be attached to the product, but it must still be easy to see. It must be at least 96mm x 192mm when printed."
   )
   @PostMapping("/display-cabinets/energy-label")
@@ -100,7 +100,7 @@ public class RefrigeratorsDirectSalesApiController {
         RefrigeratorsDirectSalesService.LEGISLATION_CATEGORY_CURRENT));
   }
 
-  @Operation(summary = "Create an arrow image for supermarket refrigerator, freezer cabinets or gelato-scooping cabinets")
+  @Operation(summary = "Supermarket refrigerator or freezer cabinets or gelato-scooping cabinets: arrow image")
   @PostMapping("/display-cabinets/arrow-image")
   public Object displayCabinetsInternetLabel(@RequestBody @Valid RefrigeratorsDirectSalesInternetLabelApiForm form) {
     return documentRendererService.processImageApiResponse(internetLabelService.generateInternetLabel(form,

--- a/src/main/java/uk/gov/beis/els/api/categories/solidfuelboilers/SolidFuelBoilersApiController.java
+++ b/src/main/java/uk/gov/beis/els/api/categories/solidfuelboilers/SolidFuelBoilersApiController.java
@@ -35,7 +35,7 @@ public class SolidFuelBoilersApiController {
   }
 
   @Operation(
-      summary = "Create an energy label for a solid fuel boiler",
+      summary = "Solid fuel boilers: energy label",
       description = "You must display the label at the point of sale so that it’s easy to see and clearly related to the product. It must be at least 105mm x 200mm when printed."
   )
   @PostMapping("/solid-fuel-boilers/energy-label")
@@ -43,7 +43,7 @@ public class SolidFuelBoilersApiController {
     return documentRendererService.processPdfApiResponse(solidFuelBoilersService.generateHtml(form, SolidFuelBoilersService.LEGISLATION_CATEGORY_CURRENT));
   }
 
-  @Operation(summary = "Create an arrow image for a solid fuel boiler")
+  @Operation(summary = "Solid fuel boilers: arrow image")
   @PostMapping("/solid-fuel-boilers/arrow-image")
   public Object solidFuelBoilersInternetLabel(@Valid @RequestBody SolidFuelBoilersInternetLabelApiForm form) {
     return documentRendererService.processImageApiResponse(
@@ -52,7 +52,7 @@ public class SolidFuelBoilersApiController {
   }
 
   @Operation(
-      summary = "Create an energy label for a package of a solid fuel boiler, supplementary heaters, temperature controls and solar devices",
+      summary = "Package of a solid fuel boiler, supplementary heaters, temperature controls and solar devices: energy label",
       description = "You must display the label at the point of sale so that it’s easy to see and clearly related to the product. It must be at least 210mm x 297mm when printed."
   )
   @PostMapping("/package-solid-fuel-boiler/energy-label")
@@ -62,7 +62,7 @@ public class SolidFuelBoilersApiController {
 
 
 
-  @Operation(summary = "Create an arrow image for a  a package of a solid fuel boiler, supplementary heaters, temperature controls and solar devices")
+  @Operation(summary = "Package of a solid fuel boiler, supplementary heaters, temperature controls and solar devices: arrow image")
   @PostMapping("/package-solid-fuel-boiler/arrow-image")
   public Object solidFuelBoilerPackagesInternetLabel(@Valid @RequestBody SolidFuelBoilersInternetLabelApiForm form) {
     return documentRendererService.processImageApiResponse(

--- a/src/main/java/uk/gov/beis/els/api/categories/televisions/TelevisionsApiController.java
+++ b/src/main/java/uk/gov/beis/els/api/categories/televisions/TelevisionsApiController.java
@@ -33,7 +33,7 @@ public class TelevisionsApiController {
   }
 
   @Operation(
-      summary = "Create an energy label for televisions",
+      summary = "Televisions and electronic displays: energy label",
       description = "You must display the label so that it’s easy to see and clearly related to the product. Labels must usually be at least 96mm x 192mm when printed. If the diagonal size of the visible screen area is less than 127cm (50 inches) you can scale down the the label, but it must still be at least 57.6mm x 115.2mm. If you scale down the label you must test that the QR code can still be read when printed, for example by using a smartphone camera."
   )
   @PostMapping("/energy-label")
@@ -41,7 +41,7 @@ public class TelevisionsApiController {
     return documentRendererService.processPdfApiResponse(televisionsService.generateHtml(form));
   }
 
-  @Operation(summary = "Create an arrow image for televisions")
+  @Operation(summary = "Televisions and electronic displays: arrow image")
   @PostMapping("/arrow-image")
   public Object televisionsInternetLabel(@RequestBody @Valid TelevisionsInternetLabelApiForm form) {
     return documentRendererService.processImageApiResponse(

--- a/src/main/java/uk/gov/beis/els/api/categories/tumbledryers/TumbleDryerApiController.java
+++ b/src/main/java/uk/gov/beis/els/api/categories/tumbledryers/TumbleDryerApiController.java
@@ -35,7 +35,7 @@ public class TumbleDryerApiController {
   }
 
   @Operation(
-      summary = "Create an energy label for an air vented tumble dryer",
+      summary = "Air vented tumble dryers: energy label",
       description = "You must attach the label to the front or top of the product so that it’s easy to see. It must be at least 110mm x 220mm when printed."
   )
   @PostMapping("/air-vented-tumble-dryers/energy-label")
@@ -43,7 +43,7 @@ public class TumbleDryerApiController {
     return documentRendererService.processPdfApiResponse(tumbleDryersService.generateHtmlAirVented(form, TumbleDryersService.LEGISLATION_CATEGORY_CURRENT));
   }
 
-  @Operation(summary = "Create an arrow image for an air vented tumble dryer")
+  @Operation(summary = "Air vented tumble dryers: arrow image")
   @PostMapping("/air-vented-tumble-dryers/arrow-image")
   public Object airVentedTumbleDryerInternetLabel(@Valid @RequestBody TumbleDryerInternetLabelApiForm form) {
     return documentRendererService.processImageApiResponse(
@@ -52,7 +52,7 @@ public class TumbleDryerApiController {
   }
 
   @Operation(
-      summary = "Create an energy label for a gas fired tumble dryer",
+      summary = "Gas fired tumble dryers: energy label",
       description = "You must attach the label to the front or top of the product so that it’s easy to see. It must be at least 110mm x 220mm when printed."
   )
   @PostMapping("/gas-fired-tumble-dryers/energy-label")
@@ -60,7 +60,7 @@ public class TumbleDryerApiController {
     return documentRendererService.processPdfApiResponse(tumbleDryersService.generateHtmlGasFired(form, TumbleDryersService.LEGISLATION_CATEGORY_CURRENT));
   }
 
-  @Operation(summary = "Create an arrow image for a gas fired tumble dryer")
+  @Operation(summary = "Gas fired tumble dryers: arrow image")
   @PostMapping("/gas-fired-tumble-dryers/arrow-image")
   public Object gasFiredTumbleDryerInternetLabel(@Valid @RequestBody TumbleDryerInternetLabelApiForm form) {
     return documentRendererService.processImageApiResponse(
@@ -69,7 +69,7 @@ public class TumbleDryerApiController {
   }
 
   @Operation(
-      summary = "Create an energy label for a condenser tumble dryer",
+      summary = "Condenser tumble dryers: energy label",
       description = "You must attach the label to the front or top of the product so that it’s easy to see. It must be at least 110mm x 220mm when printed."
   )
   @PostMapping("/condenser-tumble-dryers/energy-label")
@@ -77,7 +77,7 @@ public class TumbleDryerApiController {
     return documentRendererService.processPdfApiResponse(tumbleDryersService.generateHtmlCondenser(form, TumbleDryersService.LEGISLATION_CATEGORY_CURRENT));
   }
 
-  @Operation(summary = "Create an arrow image for a condenser tumble dryer")
+  @Operation(summary = "Condenser tumble dryers: arrow image")
   @PostMapping("/condenser-tumble-dryers/arrow-image")
   public Object condenserTumbleDryerInternetLabel(@Valid @RequestBody TumbleDryerInternetLabelApiForm form) {
     return documentRendererService.processImageApiResponse(

--- a/src/main/java/uk/gov/beis/els/api/categories/ventilationunits/VentilationUnitsApiController.java
+++ b/src/main/java/uk/gov/beis/els/api/categories/ventilationunits/VentilationUnitsApiController.java
@@ -34,7 +34,7 @@ public class VentilationUnitsApiController {
   }
 
   @Operation(
-      summary = "Create an energy label for a unidirectional ventilation unit",
+      summary = "Unidirectional ventilation units: energy label",
       description = "You must display the label so that it’s easy to see and clearly related to the product. It must be at least 75mm x 150mm when printed."
   )
   @PostMapping("/unidirectional-ventilation-units/energy-label")
@@ -42,7 +42,7 @@ public class VentilationUnitsApiController {
     return documentRendererService.processPdfApiResponse(ventilationUnitsService.generateHtmlUnidirectional(form, VentilationUnitsService.LEGISLATION_CATEGORY_CURRENT));
   }
 
-  @Operation(summary = "Create an arrow image for a unidirectional ventilation unit")
+  @Operation(summary = "Unidirectional ventilation units: arrow image")
   @PostMapping("/unidirectional-ventilation-units/arrow-image")
   public Object unidirectionalVentilationUnitInternetLabel(@Valid @RequestBody VentilationUnitsInternetLabelApiForm form) {
     return documentRendererService.processImageApiResponse(
@@ -51,7 +51,7 @@ public class VentilationUnitsApiController {
   }
 
   @Operation(
-      summary = "Create an energy label for a bidirectional ventilation unit",
+      summary = "Bidirectional ventilation units: energy label",
       description = "You must display the label so that it’s easy to see and clearly related to the product. It must be at least 75mm x 150mm when printed. "
   )
   @PostMapping("/bidirectional-ventilation-units/energy-label")
@@ -59,7 +59,7 @@ public class VentilationUnitsApiController {
     return documentRendererService.processPdfApiResponse(ventilationUnitsService.generateHtmlBidirectional(form, VentilationUnitsService.LEGISLATION_CATEGORY_CURRENT));
   }
 
-  @Operation(summary = "Create an arrow image for a bidirectional ventilation unit")
+  @Operation(summary = "Bidirectional ventilation units: arrow image")
   @PostMapping("/bidirectional-ventilation-units/arrow-image")
   public Object bidirectionalVentilationUnitInternetLabel(@Valid @RequestBody VentilationUnitsInternetLabelApiForm form) {
     return documentRendererService.processImageApiResponse(

--- a/src/main/java/uk/gov/beis/els/api/categories/washingmachines/WashingMachinesApiController.java
+++ b/src/main/java/uk/gov/beis/els/api/categories/washingmachines/WashingMachinesApiController.java
@@ -35,7 +35,7 @@ public class WashingMachinesApiController {
   }
 
   @Operation(
-      summary = "Create an energy label for washing machines",
+      summary = "Washing machines: energy label",
       description = "You must attach the label to the front or top of the product so that it’s easy to see. If it's a built-in washing machine it doesn't have to be attached to the product, but it must still be easy to see. Labels must be at least 96mm x 192mm when printed."
   )
   @PostMapping("/washing-machines/energy-label")
@@ -43,7 +43,7 @@ public class WashingMachinesApiController {
     return documentRendererService.processPdfApiResponse(washingMachinesService.generateHtml(form));
   }
 
-  @Operation(summary = "Create an arrow image for washing machines")
+  @Operation(summary = "Washing machines: arrow image")
   @PostMapping("/washing-machines/arrow-image")
   public Object washingMachinesInternetLabel(@RequestBody @Valid WashingMachinesInternetLabelApiForm form) {
     return documentRendererService.processImageApiResponse(
@@ -55,7 +55,7 @@ public class WashingMachinesApiController {
   }
 
   @Operation(
-      summary = "Create an energy label for washer-dryers",
+      summary = "Washer-dryers: energy label",
       description = "You must attach the label to the front or top of the product so that it’s easy to see. If it's a built-in washer-dryer it doesn't have to be attached to the product, but it must still be easy to see. It must be at least 96mm x 192mm when printed."
   )
   @PostMapping("/washer-dryer/energy-label")
@@ -63,7 +63,7 @@ public class WashingMachinesApiController {
     return documentRendererService.processPdfApiResponse(washingMachinesService.generateHtml(form));
   }
 
-  @Operation(summary = "Create an arrow image for washer-dryers")
+  @Operation(summary = "Washer-dryers: arrow image")
   @PostMapping("/washer-dryer/arrow-image")
   public Object washerDryerInternetLabel(@RequestBody @Valid WashingMachinesInternetLabelApiForm form) {
     return documentRendererService.processImageApiResponse(

--- a/src/main/resources/scss/components/_code.scss
+++ b/src/main/resources/scss/components/_code.scss
@@ -1,0 +1,17 @@
+.els-code {
+  font-family: monospace;
+  font-size: 1em;
+  color: #d13118; // Taken from GOV.UK Design System stylesheet; not present in the govuk colour palette
+  background: govuk-colour("light-grey");
+
+  &--inline {
+    padding: 0 govuk-spacing(1);
+  }
+
+  &--block {
+    display: block;
+    white-space: pre;
+    padding: govuk-spacing(3);
+    overflow-x: scroll;
+  }
+}

--- a/src/main/resources/scss/components/_sub-navigation.scss
+++ b/src/main/resources/scss/components/_sub-navigation.scss
@@ -1,0 +1,73 @@
+.fds-subnav {
+  $root: &;
+  margin-bottom: govuk-spacing(0);
+  padding: 0 govuk-spacing(3) 0 0;
+
+  @include govuk-media-query($from: tablet) {
+    margin-bottom: 100px;
+    @include govuk-font(16);
+  }
+
+  &--sticky {
+    position: sticky;
+    top: 0;
+  }
+
+  &__section {
+    margin: 0 0 govuk-spacing(4);
+    padding: 0;
+    list-style-type: none;
+
+    &-item {
+      margin-bottom: govuk-spacing(1);
+      padding-top: govuk-spacing(1);
+      padding-bottom: govuk-spacing(1);
+
+      &--current {
+        $_current-indicator-width: 4px;
+        margin-left: -(govuk-spacing(2) + $_current-indicator-width);
+        padding-left: govuk-spacing(2);
+        border-left: $_current-indicator-width solid govuk-colour("blue");
+        background-color: govuk-colour("white");
+
+        #{$root}__link {
+          font-weight: bold;
+        }
+      }
+    }
+
+    &--nested {
+      margin-top: govuk-spacing(2);
+      margin-bottom: 0;
+      padding-left: govuk-spacing(4);
+
+      #{$root}__section-item::before {
+        content: "—";
+        margin-left: -(govuk-spacing(4));
+        color: govuk-colour("dark-grey");
+      }
+
+      #{$root}__link {
+        padding-left: 0;
+        font-weight: normal;
+      }
+    }
+  }
+
+  &__link {
+    padding: 2px 0;
+    text-decoration: none;
+
+    &:not(:focus):hover {
+      color: $govuk-link-colour;
+      text-decoration: underline;
+    }
+  }
+
+  &__theme {
+    margin: 0;
+    padding: govuk-spacing(2) govuk-spacing(3) govuk-spacing(2) 0;
+    color: govuk-colour("dark-grey");
+    @include govuk-font(19);
+  }
+}

--- a/src/main/resources/scss/main.scss
+++ b/src/main/resources/scss/main.scss
@@ -11,3 +11,5 @@ $govuk-assets-path: "/assets/govuk-frontend/govuk/assets/";
 @import "components/buttons";
 @import "components/input";
 @import "components/arrow-icon";
+@import "components/sub-navigation";
+@import "components/code";

--- a/src/main/resources/templates/apidocumentation/apiDocumentationForTag.ftl
+++ b/src/main/resources/templates/apidocumentation/apiDocumentationForTag.ftl
@@ -1,9 +1,167 @@
 <#include '../layout.ftl'>
+<#include 'apiDocumentationNav.ftl'>
+<#import '../govuk/accordion.ftl' as govukAccordion>
 
-<@defaultPage pageHeading="${tagName}">
-  <#list operationList as operation>
-    <@govukDetails.details summaryTitle="${operation.getSummary()}">
-      ${operation.getDescription()!operation.getSummary()}
-    </@govukDetails.details>
-  </#list>
+<@defaultPage pageHeading="" twoThirdsColumn=false robotsMeta="all">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-quarter">
+      <@apiDocumentationNav/>
+    </div>
+    <div class="govuk-grid-column-three-quarters">
+      <span class="govuk-caption-xl">API endpoints</span>
+      <h1 class="govuk-heading-xl">${tagName}</h1>
+      <p class="govuk-body">
+        These endpoints return data in PDF format for energy labels, PNG or JPEG for arrow images and JSON for errors.
+      </p>
+      <p class="govuk-body">
+        You can import <a href="#" class="govuk-link">the energy label API OpenAPI 3 document</a> into API testing tools
+        like Postman to test all of our API endpoints.
+      </p>
+      <p class="govuk-body">
+        The values you send will be validated. If there are any validation errors, the response body will be a JSON object
+        containing a <code class="els-code els-code--inline">validationErrors</code> array. For example:
+      </p>
+      <p class="govuk-body">
+        <code class="els-code els-code--block">{
+    "timestamp": "2022-02-18T15:28:11.877Z",
+    "status": 400,
+    "error": "Bad request",
+    "message": "There were validation errors",
+    "validationErrors": [
+      "Field 'modelName' has error: Enter a supplier model identification code",
+      "Field 'supplierName' has error: Enter a supplier name or trade mark"
+    ],
+    "path": "/api/v1/path/to/endpoint"
+  }</code>
+      </p>
+
+      <h2 class="govuk-heading-l">Endpoints</h2>
+
+      <div class="govuk-inset-text">
+        The base URL for all paths is <code class="els-code els-code--inline">https://XXXXXXXXXXXX</code>.
+        No authentication is required for any endpoints.
+      </div>
+
+      <@govukAccordion.accordion accordionId="elg-api-operations">
+        <#list operationList as operation>
+          <@govukAccordion.accordionSection sectionHeading="${operation.getSummary()}" sectionHeadingSize="h3">
+            <#if operation.getDescription()?has_content>
+              <p class="govuk-body">
+                ${operation.getDescription()}
+              </p>
+            </#if>
+
+            <h3 class="govuk-heading-m">Path</h3>
+
+            <p class="govuk-body">
+              <code class="els-code els-code--inline">/api/v1/path/to/endpoint</code>
+            </p>
+
+            <h3 class="govuk-heading-m">Body schema</h3>
+
+            <p class="govuk-body">
+              Send a <code class="els-code els-code--inline">POST</code> request to the path above. The body of the request must be a JSON object with the following properties:
+            </p>
+
+            <table class="govuk-table">
+              <thead class="govuk-table__head">
+                <tr class="govuk-table__row">
+                  <th scope="col" class="govuk-table__header">Property</th>
+                  <th scope="col" class="govuk-table__header">Description</th>
+                  <th scope="col" class="govuk-table__header">Type</th>
+                </tr>
+              </thead>
+              <tbody class="govuk-table__body">
+                <tr class="govuk-table__row">
+                  <td class="govuk-table__cell">
+                    <code class="els-code els-code--inline">supplierName</code>
+                  </td>
+                  <td class="govuk-table__cell">
+                    Supplier's name or trade mark
+                  </td>
+                  <td class="govuk-table__cell">
+                    String
+                  </td>
+                </tr>
+                <tr class="govuk-table__row">
+                  <td class="govuk-table__cell">
+                    <code class="els-code els-code--inline">modelName</code>
+                  </td>
+                  <td class="govuk-table__cell">
+                    Supplier's model identification code
+                  </td>
+                  <td class="govuk-table__cell">
+                    String
+                  </td>
+                </tr>
+                <tr class="govuk-table__row">
+                  <td class="govuk-table__cell">
+                    <code class="els-code els-code--inline">efficiencyRating</code>
+                  </td>
+                  <td class="govuk-table__cell">
+                    The energy efficiency class of the cavity. Must be one of
+                    <code class="els-code els-code--inline">A+++</code>,
+                    <code class="els-code els-code--inline">A++</code>,
+                    <code class="els-code els-code--inline">A+</code>,
+                    <code class="els-code els-code--inline">A</code>,
+                    <code class="els-code els-code--inline">B</code>,
+                    <code class="els-code els-code--inline">C</code>,
+                    <code class="els-code els-code--inline">D</code>
+                  </td>
+                  <td class="govuk-table__cell">
+                    String
+                  </td>
+                </tr>
+                <tr class="govuk-table__row">
+                  <td class="govuk-table__cell">
+                    <code class="els-code els-code--inline">volume</code>
+                  </td>
+                  <td class="govuk-table__cell">
+                    Usable volume of the cavity in litres (L). This may be up to 3 digit(s) long.
+                  </td>
+                  <td class="govuk-table__cell">
+                    Integer
+                  </td>
+                </tr>
+                <tr class="govuk-table__row">
+                  <td class="govuk-table__cell">
+                    <code class="els-code els-code--inline">conventionalKwhConsumption</code>
+                  </td>
+                  <td class="govuk-table__cell">
+                    Energy consumption of the conventional heating function per cycle, in kWh/cycle. This may be up to 1 digit(s) long with an optional 2 decimal places.
+                  </td>
+                  <td class="govuk-table__cell">
+                    Number
+                  </td>
+                </tr>
+                <tr class="govuk-table__row">
+                  <td class="govuk-table__cell">
+                    <code class="els-code els-code--inline">isFanOven</code>
+                  </td>
+                  <td class="govuk-table__cell">
+                    Is this a fan-forced oven?
+                  </td>
+                  <td class="govuk-table__cell">
+                    Boolean
+                  </td>
+                </tr>
+                <tr class="govuk-table__row">
+                  <td class="govuk-table__cell">
+                    <code class="els-code els-code--inline">convectionKwhConsumption</code>
+                  </td>
+                  <td class="govuk-table__cell">
+                    Energy consumption of the fan-forced heating function per cycle, in kWh/cycle. This may be up to 1 digit(s) long with an optional 2 decimal places.
+                  </td>
+                  <td class="govuk-table__cell">
+                    Number
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+
+          </@govukAccordion.accordionSection>
+        </#list>
+      </@govukAccordion.accordion>
+    </div>
+  </div>
 </@defaultPage>

--- a/src/main/resources/templates/apidocumentation/apiDocumentationNav.ftl
+++ b/src/main/resources/templates/apidocumentation/apiDocumentationNav.ftl
@@ -1,0 +1,21 @@
+<#import '../fds/subNavigation.ftl' as fdsSubNavigation>
+
+<#macro apiDocumentationNav>
+  <@fdsSubNavigation.subNavigation>
+    <@fdsSubNavigation.subNavigationSection>
+      <@fdsSubNavigation.subNavigationSectionItem linkAction="/api-documentation" linkName="About the API" currentItemHref="dummy"/>
+      <@fdsSubNavigation.subNavigationSectionItem linkAction="/api-documentation#rate-limits" linkName="Rate limits" currentItemHref="dummy"/>
+      <@fdsSubNavigation.subNavigationSectionItem linkAction="/api-documentation#testing" linkName="Testing" currentItemHref="dummy"/>
+      <@fdsSubNavigation.subNavigationSectionItem linkAction="/api-documentation#versioning" linkName="Versioning" currentItemHref="dummy"/>
+      <@fdsSubNavigation.subNavigationSectionItem linkAction="/api-documentation#availability" linkName="Availability" currentItemHref="dummy"/>
+      <@fdsSubNavigation.subNavigationSectionItem linkAction="/api-documentation#support" linkName="Support" currentItemHref="dummy"/>
+      <@fdsSubNavigation.subNavigationSectionItem linkAction="/api-documentation#email-updates" linkName="Email updates" currentItemHref="dummy"/>
+      <@fdsSubNavigation.subNavigationSectionItem linkAction="/api-documentation#version-history-release-notes" linkName="Version history" currentItemHref="dummy"/>
+    </@fdsSubNavigation.subNavigationSection>
+    <@fdsSubNavigation.subNavigationSection themeHeading="Endpoints">
+      <#list tagLinks as tagLink>
+        <@fdsSubNavigation.subNavigationSectionItem linkAction=tagLink.url linkName=tagLink.name currentItemHref=currentUrl/>
+      </#list>
+    </@fdsSubNavigation.subNavigationSection>
+  </@fdsSubNavigation.subNavigation>
+</#macro>

--- a/src/main/resources/templates/apidocumentation/apiDocumentationStartPage.ftl
+++ b/src/main/resources/templates/apidocumentation/apiDocumentationStartPage.ftl
@@ -1,9 +1,155 @@
 <#include '../layout.ftl'>
+<#include 'apiDocumentationNav.ftl'>
 
-<@defaultPage pageHeading="API documentation">
-  <ul class="govuk-list govuk-list--bullet">
-    <#list tagLinks as tagLink>
-        <li><a class="govuk-link" href="${tagLink.url}">${tagLink.name}</a></li>
-    </#list>
-  </ul>
+<@defaultPage pageTitle="The energy label API" twoThirdsColumn=false robotsMeta="all">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-quarter">
+      <@apiDocumentationNav/>
+    </div>
+    <div class="govuk-grid-column-three-quarters">
+      <h1 class="govuk-heading-xl" id="about-api">
+        The energy label API
+      </h1>
+
+      <p class="govuk-body">
+        The energy label API lets you create energy labels for products sold in Great Britain.
+      </p>
+
+      <div class="govuk-inset-text">
+        If you want to create a single energy label or you're not a developer, you can
+        <a href="${serviceHomePageUrl}" class="govuk-link">use the 'create an energy label' service</a> instead.
+      </div>
+
+      <p class="govuk-body">
+        You can use the API to create energy labels in your own applications from your product data. You can create
+        any of the types of label that are available on this service, as well as efficiency class arrow images for
+        websites and other distance selling.
+      </p>
+      <p class="govuk-body">
+        The energy label API is free to use and you don't need to register, but you can
+        <a class="govuk-link" href="#">sign up to receive email updates</a>.
+      </p>
+
+      <h2 class="govuk-heading-m" id="rate-limits">
+        Rate limits
+      </h2>
+      <p class="govuk-body">
+        Requests to the energy label API are rate limited to X requests per second per IP address.
+      </p>
+      <p class="govuk-body">
+        You should store the labels you generate in your application, rather than making repeated requests
+        for the same product's label. This will help you avoid being rate limited.
+      </p>
+      <p class="govuk-body">
+        If you exceed the rate limit, you'll receive a response with the <code class="els-code els-code--inline">429 Too Many Requests</code>
+        HTTP status code. You can retry your request in 1 second.
+      </p>
+
+      <h2 class="govuk-heading-m" id="testing">
+        Testing
+      </h2>
+      <p class="govuk-body">
+        The energy label API doesn't require authentication and doesn't store the labels you create, so there is no
+        sandbox environment for testing. You can use the live API URL for development, testing and production.
+      </p>
+      <p class="govuk-body">
+        You can import <a href="#" class="govuk-link">the energy label API OpenAPI 3 document</a> into API testing tools
+        like Postman to test all of our API endpoints.
+      </p>
+
+      <h2 class="govuk-heading-m" id="versioning">
+        Versioning
+      </h2>
+      <p class="govuk-body">
+        The current version of the energy label API is v1.
+      </p>
+      <p class="govuk-body">
+        We'll only change the version number of the API if we make changes that might break applications using the API.
+        These changes include:
+      </p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>changing the intended behaviour of any existing endpoints</li>
+        <li>removing endpoints</li>
+      </ul>
+      <p class="govuk-body">
+        We will not change the version number of the API for changes that:
+      </p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>add new endpoints</li>
+        <li>fix bugs, unless the fix could break existing applications</li>
+      </ul>
+      <p class="govuk-body">
+        If you <a href="#email-updates" class="govuk-link">sign up to receive emails from us</a> we'll email you to let you know when
+        we make changes to the API or release a new version. We'll also add a notice to this page.
+      </p>
+      <p class="govuk-body">
+        After we've released a new version of the API, the previous version will keep working for at least 6 months.
+        This will give you time to update your application to use the new version. When we announce a new version, we'll
+        tell you when the old version will stop working.
+      </p>
+      <p class="govuk-body">
+        When we release a new version of the API, all of our endpoint paths will change to include the new version number.
+        You'll need to update the endpoint URLs your application uses to access the API. You'll need to test that your
+        application still works with the new version. You should read the
+        <a class="govuk-link" href="#version-history-release-notes">release notes for the current version</a>
+        to see what's changed and update your application if necessary.
+      </p>
+
+      <h2 class="govuk-heading-m" id="availability">
+        Availability
+      </h2>
+      <p class="govuk-body">
+        We aim to make the energy label API available 24 hours a day, 7 days a week. However, availability of the API is not
+        guaranteed and there may be unexpected downtime or performance degradation at any time. Your application should be
+        resilient to the energy label API not being available, for example:
+      </p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>taking a long time to send a response</li>
+        <li>timing out before sending a response</li>
+        <li>
+          returning responses with HTTP status codes other than <code class="els-code els-code--inline">200 OK</code>,
+          including 5xx server error status codes
+        </li>
+      </ul>
+      <p class="govuk-body">
+        You should store the labels you generate in your application, rather than making repeated requests for the same
+        product's label. This will limit the impact of any downtime on your application.
+      </p>
+      <p class="govuk-body">
+        If you <a href="#email-updates" class="govuk-link">sign up to receive emails from us</a> we'll email you before any planned
+        downtime, or to update you on any unplanned downtime.
+      </p>
+
+      <h2 class="govuk-heading-m" id="support">
+        Support
+      </h2>
+      <p class="govuk-body">
+        If you've found a bug or you have issues accessing the energy label API, suggestions for new features or any
+        other feedback, please contact
+        <a class="govuk-link" href="mailto:efficientproducts@beis.gov.uk?subject=Energy label API feedback">
+          efficientproducts@beis.gov.uk
+        </a>
+      </p>
+
+      <h2 class="govuk-heading-m" id="email-updates">
+        Email updates
+      </h2>
+      <p class="govuk-body">
+        You can <a class="govuk-link" href="#">sign up to receive email updates about the energy label API</a>. We'll
+        notify you about any downtime and let you know when we make important changes.
+      </p>
+      <p class="govuk-body">
+        You don't have to sign up for email updates to use the API, but we encourage you to sign up if you're using the API
+        in production. If you don't, you may not find out about downtime or changes that affect your application.
+      </p>
+
+      <h2 class="govuk-heading-m" id="version-history-release-notes">
+        Version history and release notes
+      </h2>
+      <h3 class="govuk-heading-s">v1</h3>
+      <p class="govuk-body">
+        This is the first version of the energy label API.
+      </p>
+    </div>
+  </div>
 </@defaultPage>

--- a/src/main/resources/templates/fds/subNavigation.ftl
+++ b/src/main/resources/templates/fds/subNavigation.ftl
@@ -1,0 +1,53 @@
+<#import '/spring.ftl' as spring>
+
+<#function springUrl url>
+  <#local springUrl>
+    <@spring.url url/>
+  </#local>
+  <#return springUrl>
+</#function>
+
+<#--Sub Navigation Component (left hand navigation)-->
+<#macro subNavigation sticky=false>
+  <nav class="fds-subnav<#if sticky> fds-subnav--sticky</#if>"<#if sticky> data-module="fds-subnav-sticky"</#if> title="Sub navigation">
+    <#nested>
+  </nav>
+</#macro>
+
+<#macro subNavigationSection themeHeading="">
+  <#if themeHeading?has_content>
+  <h4 class="fds-subnav__theme">${themeHeading}</h4>
+  </#if>
+  <ul class="fds-subnav__section">
+    <#nested>
+  </ul>
+</#macro>
+
+<#macro subNavigationSectionItem linkAction linkName currentItemHref>
+  <#if currentItemHref?starts_with(linkAction)>
+    <#local currentClass="fds-subnav__section-item--current">
+    <#local currentAriaAttr='aria-current="true"'>
+  <#else>
+    <#local currentClass="">
+    <#local currentAriaAttr="">
+  </#if>
+
+  <li class="fds-subnav__section-item ${currentClass}" ${currentAriaAttr}>
+    <a class="fds-subnav__link govuk-link govuk-link--no-visited-state" href="${linkAction}">${linkName}</a>
+    <#if currentItemHref?starts_with(linkAction) && currentItemHref!="/">
+      <#nested>
+    </#if>
+  </li>
+</#macro>
+
+<#macro subNavigationNested>
+  <ul class="fds-subnav__section fds-subnav__section--nested">
+    <#nested>
+  </ul>
+</#macro>
+
+<#macro subNavigationNestedLink linkUrl linkText>
+  <li class="fds-subnav__section-item">
+    <a class="fds-subnav__link govuk-link govuk-link--no-visited-state" href="${linkUrl}">${linkText}</a>
+  </li>
+</#macro>

--- a/src/main/resources/templates/govuk/accordion.ftl
+++ b/src/main/resources/templates/govuk/accordion.ftl
@@ -1,0 +1,31 @@
+<#--Accordion Component-->
+<#-- https://design-system.service.gov.uk/components/accordion/ -->
+<#global accordionCounter></#global>
+<#global accordionGlobalId></#global>
+
+<#macro accordion accordionId>
+    <#assign accordionCounter = 1>
+    <#assign accordionGlobalId = accordionId>
+  <div class="govuk-accordion" data-module="govuk-accordion" id="${accordionGlobalId}">
+      <#nested>
+  </div>
+</#macro>
+
+<#macro accordionSection sectionHeading sectionHeadingSize="h2" summaryText="">
+  <div class="govuk-accordion__section ">
+    <div class="govuk-accordion__section-header">
+      <${sectionHeadingSize} class="govuk-accordion__section-heading">
+      <span class="govuk-accordion__section-button" id="${accordionGlobalId}-heading-${accordionCounter}">${sectionHeading}</span>
+    </${sectionHeadingSize}>
+      <#if summaryText?has_content>
+        <div class="govuk-accordion__section-summary govuk-body" id="${accordionGlobalId}-summary-${accordionCounter}">
+            ${summaryText}
+        </div>
+      </#if>
+  </div>
+  <div id="${accordionGlobalId}-content-${accordionCounter}" class="govuk-accordion__section-content" aria-labelledby="${accordionGlobalId}-heading-${accordionCounter}">
+      <#nested>
+  </div>
+  </div>
+    <#assign accordionCounter++>
+</#macro>

--- a/src/main/resources/templates/govuk/footer.ftl
+++ b/src/main/resources/templates/govuk/footer.ftl
@@ -8,6 +8,11 @@
           <h2 class="govuk-visually-hidden">Support links</h2>
           <ul class="govuk-footer__inline-list">
             <li class="govuk-footer__inline-list-item">
+              <a class="govuk-footer__link" href="/api-documentation">
+                Energy label API
+              </a>
+            </li>
+            <li class="govuk-footer__inline-list-item">
               <a class="govuk-footer__link" href="/cookies">
                 Cookies
               </a>

--- a/src/main/resources/templates/layout.ftl
+++ b/src/main/resources/templates/layout.ftl
@@ -40,6 +40,7 @@
   pageScripts=blankMacro
   notificationBanner=blankMacro
   beforeStandardInsetText=""
+  robotsMeta="noindex, nofollow"
   >
 
   <#--Checks if the heading has content in order to not display an empty <h1>-->
@@ -54,7 +55,7 @@
   <title><#if errorList?has_content>Error: </#if><#if pageTitle?has_content>${pageTitle} - <#elseif pageHeading?has_content>${pageHeading} - </#if>Create an energy label - GOV.UK</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="theme-color" content="#0b0c0c" />
-  <meta name="robots" content="noindex, nofollow" />
+  <meta name="robots" content="${robotsMeta}" />
   <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="<@spring.url'/assets/govuk-frontend/govuk/assets/images/favicon.ico'/>" type="image/x-icon" />
   <link rel="mask-icon" href="<@spring.url'/assets/govuk-frontend/govuk/assets/images/govuk-mask-icon.svg'/>" color="#0b0c0c">
   <link rel="apple-touch-icon" sizes="180x180" href="<@spring.url'/assets/govuk-frontend/govuk/assets/images/govuk-apple-touch-icon-180x180.png'/>">
@@ -119,6 +120,13 @@
               </#if>
               </span>
             </#if>
+
+            <#if caption?has_content>
+              <span class="${captionClass}">
+                ${caption}
+              </span>
+            </#if>
+
             <#--GOVUK heading class names https://design-system.service.gov.uk/styles/typography/-->
             <#if heading>
               <h1 class="${headingCssClass}">${pageHeading}</h1>

--- a/src/test/java/uk/gov/beis/els/ControllerSmokeTest.java
+++ b/src/test/java/uk/gov/beis/els/ControllerSmokeTest.java
@@ -57,7 +57,7 @@ public class ControllerSmokeTest {
 
     List<String> getRoutes = requestMappingHandlerMapping.getHandlerMethods().keySet().stream()
         .filter(r -> r.getMethodsCondition().getMethods().contains(RequestMethod.GET))
-        .map(r -> (String) r.getDirectPaths().toArray()[0])
+        .map(r -> (String) r.getPatternValues().toArray()[0])
         .filter(path -> !StringUtils.startsWithAny(path, ignoredEndpoints.toArray(new CharSequence[0])))
         .collect(Collectors.toList());
 


### PR DESCRIPTION
Still WIP - whoever picks up the implementation will need to:
- update the URL for the OpenAPI doco in the 'Testing' section and in the heading of each product category ("You can import...")
- update the rate limit in the 'rate limits' section ("are rate limited to...")
- Show real base path on each endpoints page ("The base URL for all paths is...")
- Show real path for each endpoint
- Show real schema properties for each endpoint

We'll need to update the email signup URL when that decision has been made