### PR TITLE
Feature/ELG-35/validate rating ranges passed to API endpoints

### DIFF
--- a/src/main/java/uk/gov/beis/els/api/common/ApiValuesFromEnum.java
+++ b/src/main/java/uk/gov/beis/els/api/common/ApiValuesFromEnum.java
@@ -4,13 +4,20 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
 
 /**
  * Set which values can be used in an API call from an enum
  * The Enum must implement the Displayable interface
  */
+@Constraint(validatedBy = ApiValuesFromEnumValidator.class)
 @Target({ElementType.METHOD, ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ApiValuesFromEnum {
+
+  String message() default "{uk.gov.beis.els.api.common.ApiValuesFromEnum.message}";
+  Class<?>[] groups() default {};
+  Class<? extends Payload>[] payload() default {};
   Class<?> value();
 }

--- a/src/main/java/uk/gov/beis/els/api/common/ApiValuesFromEnumValidator.java
+++ b/src/main/java/uk/gov/beis/els/api/common/ApiValuesFromEnumValidator.java
@@ -1,0 +1,40 @@
+package uk.gov.beis.els.api.common;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import org.apache.commons.lang3.StringUtils;
+import uk.gov.beis.els.model.Displayable;
+
+public class ApiValuesFromEnumValidator implements ConstraintValidator<ApiValuesFromEnum, String> {
+
+  Method method;
+
+  @Override
+  public void initialize(ApiValuesFromEnum constraintAnnotation) {
+    try {
+      method = constraintAnnotation.value().getMethod("getEnum", String.class);
+    } catch (NoSuchMethodException e) {
+      throw new RuntimeException(String.format("Cannot access getEnum method in %s", constraintAnnotation.value()), e);
+    }
+  }
+
+  @Override
+  public boolean isValid(String value, ConstraintValidatorContext context) {
+    if (StringUtils.isBlank(value)) {
+      return true; //avoid getting duplicate validation errors as this will get picked up by the existing @NotBlank annotation
+    }
+
+    Displayable resolvedEnum;
+    try {
+      resolvedEnum = (Displayable) method.invoke(null, value);
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException("Cannot invoke getEnum()", e);
+    } catch (InvocationTargetException e) { //We ignore the IllegalArgumentException from getEnum() as that gets wrapped in an InvocationTargetException
+      return false;
+    }
+
+    return resolvedEnum != null;
+  }
+}

--- a/src/main/java/uk/gov/beis/els/api/common/ApiValuesFromLegislationCategory.java
+++ b/src/main/java/uk/gov/beis/els/api/common/ApiValuesFromLegislationCategory.java
@@ -4,6 +4,8 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
 
 /**
  * Fields with this annotation will have their allowableValues constraint in the OpenAPI specification set dynamically based on
@@ -11,9 +13,14 @@ import java.lang.annotation.Target;
  *
  * This will override any static allowableValues set in a @ApiModelProperty annotation.
  */
+@Constraint(validatedBy = ApiValuesFromLegislationCategoryValidator.class)
 @Target({ElementType.METHOD, ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
-public @interface ApiValuesFromLegislationCategory {
+public @interface ApiValuesFromLegislationCategory{
+
+  String message() default "{uk.gov.beis.els.api.common.ApiValuesFromLegislationCategory.message}";
+  Class<?>[] groups() default {};
+  Class<? extends Payload>[] payload() default {};
 
   /**
    * @return The class which contains the LegislationCategory field

--- a/src/main/java/uk/gov/beis/els/api/common/ApiValuesFromLegislationCategoryValidator.java
+++ b/src/main/java/uk/gov/beis/els/api/common/ApiValuesFromLegislationCategoryValidator.java
@@ -17,7 +17,7 @@ public class ApiValuesFromLegislationCategoryValidator implements ConstraintVali
     LegislationCategory legislationCategory;
     try {
       Field field = constraintAnnotation.serviceClass().getField(constraintAnnotation.legislationCategoryFieldName());
-      legislationCategory = (LegislationCategory) field.get(null); // Null as we're accessing a static field
+      legislationCategory = (LegislationCategory) field.get(null);
     } catch (NoSuchFieldException | IllegalAccessException e) {
       throw new RuntimeException("Cannot get LegislationCategory", e);
     }

--- a/src/main/java/uk/gov/beis/els/api/common/ApiValuesFromLegislationCategoryValidator.java
+++ b/src/main/java/uk/gov/beis/els/api/common/ApiValuesFromLegislationCategoryValidator.java
@@ -1,0 +1,44 @@
+package uk.gov.beis.els.api.common;
+
+import java.lang.reflect.Field;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import org.apache.commons.lang3.StringUtils;
+import uk.gov.beis.els.model.LegislationCategory;
+import uk.gov.beis.els.model.RatingClass;
+import uk.gov.beis.els.model.RatingClassRange;
+
+public class ApiValuesFromLegislationCategoryValidator implements ConstraintValidator<ApiValuesFromLegislationCategory, String> {
+
+  private RatingClassRange range;
+
+  @Override
+  public void initialize(ApiValuesFromLegislationCategory constraintAnnotation) {
+    LegislationCategory legislationCategory;
+    try {
+      Field field = constraintAnnotation.serviceClass().getField(constraintAnnotation.legislationCategoryFieldName());
+      legislationCategory = (LegislationCategory) field.get(null); // Null as we're accessing a static field
+    } catch (NoSuchFieldException | IllegalAccessException e) {
+      throw new RuntimeException("Cannot get LegislationCategory", e);
+    }
+
+    if (constraintAnnotation.useSecondaryRange()) {
+      range = legislationCategory.getSecondaryRatingRange();
+    } else {
+      range = legislationCategory.getPrimaryRatingRange();
+    }
+  }
+
+  @Override
+  public boolean isValid(String value, ConstraintValidatorContext context) {
+    if (StringUtils.isBlank(value)) {
+      return true; //avoid getting duplicate validation errors as this will get picked up by the existing @NotBlank annotation
+    }
+
+    try {
+      return range.getApplicableRatings().contains(RatingClass.getEnum(value));
+    } catch (IllegalArgumentException e) {
+      return false;
+    }
+  }
+}

--- a/src/main/java/uk/gov/beis/els/api/common/ApiValuesFromRatingClassRange.java
+++ b/src/main/java/uk/gov/beis/els/api/common/ApiValuesFromRatingClassRange.java
@@ -5,6 +5,8 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
 
 /**
  * Fields with this annotation will have their allowableValues constraint in the OpenAPI specification set dynamically based on
@@ -12,9 +14,14 @@ import java.lang.annotation.Target;
  *
  * This will override any static allowableValues set in a @ApiModelProperty annotation.
  */
+@Constraint(validatedBy = ApiValuesFromRatingClassRangeValidator.class)
 @Target({ElementType.METHOD, ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ApiValuesFromRatingClassRange {
+  String message() default "{uk.gov.beis.els.api.common.ApiValuesFromRatingClassRange.message}";
+  Class<?>[] groups() default {};
+  Class<? extends Payload>[] payload() default {};
+
 
   /**
    * @return The class which contains the RatingClassRange field

--- a/src/main/java/uk/gov/beis/els/api/common/ApiValuesFromRatingClassRangeValidator.java
+++ b/src/main/java/uk/gov/beis/els/api/common/ApiValuesFromRatingClassRangeValidator.java
@@ -1,0 +1,36 @@
+package uk.gov.beis.els.api.common;
+
+import java.lang.reflect.Field;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import org.apache.commons.lang3.StringUtils;
+import uk.gov.beis.els.model.RatingClass;
+import uk.gov.beis.els.model.RatingClassRange;
+
+public class ApiValuesFromRatingClassRangeValidator implements ConstraintValidator<ApiValuesFromRatingClassRange, String> {
+
+  private RatingClassRange range;
+
+  @Override
+  public void initialize(ApiValuesFromRatingClassRange constraintAnnotation) {
+    try {
+      Field field = constraintAnnotation.serviceClass().getField(constraintAnnotation.ratingClassRangeFieldName());
+      range = (RatingClassRange) field.get(null);
+    } catch (NoSuchFieldException | IllegalAccessException e) {
+      throw new RuntimeException("Cannot get RatingClassRange", e);
+    }
+  }
+
+  @Override
+  public boolean isValid(String value, ConstraintValidatorContext context) {
+    if (StringUtils.isBlank(value)) {
+      return true; //avoid getting duplicate validation errors as this will get picked up by the existing @NotBlank annotation
+    }
+
+    try {
+      return range.getApplicableRatings().contains(RatingClass.getEnum(value));
+    } catch (IllegalArgumentException e) {
+      return false;
+    }
+  }
+}

--- a/src/main/resources/ValidationMessages.properties
+++ b/src/main/resources/ValidationMessages.properties
@@ -2,3 +2,4 @@ javax.validation.constraints.NotBlank.message=This information must be provided
 javax.validation.constraints.NotNull.message=This information must be provided
 uk.gov.beis.els.api.common.ApiValuesFromLegislationCategory.message=Efficiency rating is not within range
 uk.gov.beis.els.api.common.ApiValuesFromRatingClassRange.message=Efficiency rating is not within range
+uk.gov.beis.els.api.common.ApiValuesFromEnum.message=Invalid value

--- a/src/main/resources/ValidationMessages.properties
+++ b/src/main/resources/ValidationMessages.properties
@@ -1,2 +1,4 @@
 javax.validation.constraints.NotBlank.message=This information must be provided
 javax.validation.constraints.NotNull.message=This information must be provided
+uk.gov.beis.els.api.common.ApiValuesFromLegislationCategory.message=Efficiency rating is not within range
+uk.gov.beis.els.api.common.ApiValuesFromRatingClassRange.message=Efficiency rating is not within range


### PR DESCRIPTION
- Added constraint validators for `ApiValuesFromLegislationCategory` and `ApiValuesFromRatingClassRange`.
Validate the `EfficiencyClass` to be within the ranges of the current legislation. Both the `displayName `and Enum name will be accepted.

- Constraint validator for `ApiValuesFromEnum`. Used reflection to validate that the provided string belongs to the desired Enum. Both the `DisplayName` and Enum name are accepted