### PR TITLE
Add support for multiple HTML documents in a single PDF

### DIFF
--- a/src/main/java/uk/gov/beis/els/renderer/PdfRenderer.java
+++ b/src/main/java/uk/gov/beis/els/renderer/PdfRenderer.java
@@ -1,10 +1,13 @@
 package uk.gov.beis.els.renderer;
 
 import com.google.common.base.Stopwatch;
+import com.openhtmltopdf.pdfboxout.PdfBoxRenderer;
 import com.openhtmltopdf.pdfboxout.PdfRendererBuilder;
 import com.openhtmltopdf.svgsupport.BatikSVGDrawer;
 import java.io.ByteArrayOutputStream;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
+import org.apache.pdfbox.pdmodel.PDDocument;
 import org.jsoup.nodes.Document;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,6 +39,38 @@ public class PdfRenderer implements Renderer {
       return new ByteArrayResource(os.toByteArray());
     } catch (Exception e) {
       throw new RuntimeException("Error rendering template to PDF", e);
+    }
+  }
+
+  public Resource render(List<Document> documents) {
+
+    try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+
+      Stopwatch renderStopwatch = Stopwatch.createStarted();
+
+      PDDocument collatedDocument = new PDDocument();
+      PdfRendererBuilder builder = new PdfRendererBuilder();
+
+      for(Document document : documents) {
+        builder.withHtmlContent(document.outerHtml(), "classpath://");
+        builder.useSVGDrawer(new BatikSVGDrawer());
+        builder.usePDDocument(collatedDocument);
+
+        PdfBoxRenderer renderer = builder.buildPdfRenderer();
+        renderer.layout();
+
+        // Keep the doc open but close the renderer
+        renderer.createPDFWithoutClosing();
+        renderer.close();
+      }
+
+      collatedDocument.save(os);
+
+      LOGGER.info("Collated PDF label generated. Took [{}ms]", renderStopwatch.elapsed(TimeUnit.MILLISECONDS));
+
+      return new ByteArrayResource(os.toByteArray());
+    } catch (Exception e) {
+      throw new RuntimeException("Error rendering collated templates to PDF", e);
     }
   }
 

--- a/src/test/java/uk/gov/beis/els/service/DocumentRendererServiceTest.java
+++ b/src/test/java/uk/gov/beis/els/service/DocumentRendererServiceTest.java
@@ -4,12 +4,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.pdfbox.pdmodel.PDDocument;
 import org.jsoup.Jsoup;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.core.io.ByteArrayResource;
 import org.springframework.http.ResponseEntity;
 import uk.gov.beis.els.categories.common.ProcessedEnergyLabelDocument;
 import uk.gov.beis.els.categories.common.ProcessedInternetLabelDocument;
@@ -33,14 +38,37 @@ public class DocumentRendererServiceTest {
   }
 
   @Test
-  public void testProcessPdfResponse() {
+  public void testProcessPdfResponse() throws IOException {
     ProcessedEnergyLabelDocument doc = new ProcessedEnergyLabelDocument(
-        Jsoup.parse("<title>Dishwashers - name - model</title>"), ProductMetadata.DISHWASHERS, "x", "name - model");
+        Jsoup.parse("<html><head><title>Dishwashers - name - model</title></head><body>foo</body></html>"), ProductMetadata.DISHWASHERS, "x", "name - model");
 
     ResponseEntity responseEntity = documentRendererService.processPdfResponse(doc);
 
+    PDDocument generatedPdf = PDDocument.load(((ByteArrayResource)responseEntity.getBody()).getByteArray());
+    assertThat(generatedPdf.getNumberOfPages()).isEqualTo(1);
+
     assertThat(responseEntity.getHeaders().getContentDisposition().getFilename()).isEqualTo("Dishwashers - name - model.pdf");
 
+    verify(analyticsService, times(1))
+        .sendGoogleAnalyticsEvent("x", GoogleAnalyticsEventCategory.ENERGY_LABEL, "name - model", ProductMetadata.DISHWASHERS.getAnalyticsLabel());
+  }
+
+  @Test
+  public void testProcessPdfResponse_MultiplePages() throws IOException {
+    List<ProcessedEnergyLabelDocument> docs = new ArrayList<>();
+
+    docs.add(new ProcessedEnergyLabelDocument(
+        Jsoup.parse("<title>Fiche 1</title>"), ProductMetadata.DISHWASHERS, "x", "name - model"));
+    docs.add(new ProcessedEnergyLabelDocument(
+        Jsoup.parse("<title>Fiche 2</title>"), ProductMetadata.OVENS_ELECTRIC, "x", "name - model"));
+
+    ResponseEntity responseEntity = documentRendererService.processPdfResponse(docs);
+
+    PDDocument generatedPdf = PDDocument.load(((ByteArrayResource)responseEntity.getBody()).getByteArray());
+    assertThat(generatedPdf.getNumberOfPages()).isEqualTo(2);
+
+    // The metadata from the first document should be used.
+    assertThat(responseEntity.getHeaders().getContentDisposition().getFilename()).isEqualTo("Fiche 1.pdf");
     verify(analyticsService, times(1))
         .sendGoogleAnalyticsEvent("x", GoogleAnalyticsEventCategory.ENERGY_LABEL, "name - model", ProductMetadata.DISHWASHERS.getAnalyticsLabel());
   }


### PR DESCRIPTION
You can now pass a List of `ProcessedEnergyLabelDocument`s to the renderer and the docs will be combined into a single PDF, as required for the combination heaters fiche.