### PR TITLE
New 'Endpoints' doco section and update openapi url

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Run OpenAPI tests
         run: |
           pip install schemathesis
-          schemathesis run --hypothesis-phases=explicit http://localhost:8080/api/v1/openapi
+          schemathesis run --hypothesis-phases=explicit http://localhost:8080/api/v1/energy-labels-openapi.json
 
       - name: Install cf client
         env:

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -18,7 +18,7 @@ api.v1.rate-limit.time_unit=${RATE_LIMIT_TIME_UNIT:minutes}
 springdoc.pathsToMatch=${api.v1.base_path}/**
 
 # This is excluded from pathsToMatch automatically
-springdoc.api-docs.path=${api.v1.base_path}/openapi
+springdoc.api-docs.path=${api.v1.base_path}/energy-labels-openapi.json
 springdoc.swagger-ui.enabled=${ENABLE_SWAGGER_UI:false}
 # For sorting endpoints alphabetically
 springdoc.swagger-ui.operationsSorter=alpha

--- a/src/main/resources/scss/helpers/_typography.scss
+++ b/src/main/resources/scss/helpers/_typography.scss
@@ -4,10 +4,8 @@
   }
 }
 
-span.els-non-mobile-only { // Scoped to spans only because other elements would need different display values
-  display: none;
-
-  @include govuk-media-query($from: tablet) {
-    display: inline;
+.els-non-mobile-only {
+  @include govuk-media-query($until: tablet) {
+    display: none;
   }
 }

--- a/src/main/resources/scss/helpers/_typography.scss
+++ b/src/main/resources/scss/helpers/_typography.scss
@@ -1,0 +1,13 @@
+.els-mobile-only {
+  @include govuk-media-query($from: tablet) {
+    display: none;
+  }
+}
+
+span.els-non-mobile-only { // Scoped to spans only because other elements would need different display values
+  display: none;
+
+  @include govuk-media-query($from: tablet) {
+    display: inline;
+  }
+}

--- a/src/main/resources/scss/main.scss
+++ b/src/main/resources/scss/main.scss
@@ -3,6 +3,9 @@ $govuk-assets-path: "/assets/govuk-frontend/govuk/assets/";
 // import ALL GOVUK components
 @import '../public/assets/govuk-frontend/govuk/all';
 
+// Helpers
+@import "helpers/typography";
+
 // GOVUK Patterns
 @import "patterns/task-list";
 

--- a/src/main/resources/templates/apidocumentation/apiDocumentationNav.ftl
+++ b/src/main/resources/templates/apidocumentation/apiDocumentationNav.ftl
@@ -4,6 +4,7 @@
   <@fdsSubNavigation.subNavigation>
     <@fdsSubNavigation.subNavigationSection>
       <@fdsSubNavigation.subNavigationSectionItem linkAction="/api-documentation" linkName="About the API" currentItemHref="dummy"/>
+      <@fdsSubNavigation.subNavigationSectionItem linkAction="/api-documentation#endpoints" linkName="Endpoints" currentItemHref="dummy"/>
       <@fdsSubNavigation.subNavigationSectionItem linkAction="/api-documentation#rate-limits" linkName="Rate limits" currentItemHref="dummy"/>
       <@fdsSubNavigation.subNavigationSectionItem linkAction="/api-documentation#testing" linkName="Testing" currentItemHref="dummy"/>
       <@fdsSubNavigation.subNavigationSectionItem linkAction="/api-documentation#validation" linkName="Request validation" currentItemHref="dummy"/>

--- a/src/main/resources/templates/apidocumentation/apiDocumentationStartPage.ftl
+++ b/src/main/resources/templates/apidocumentation/apiDocumentationStartPage.ftl
@@ -30,7 +30,7 @@
         <a class="govuk-link" href="#">sign up to receive email updates</a>.
       </p>
 
-      <h2 class="govuk-heading-m" id="rate-limits">
+      <h2 class="govuk-heading-m" id="endpoints">
         Endpoints
       </h2>
       <p class="govuk-body">

--- a/src/main/resources/templates/apidocumentation/apiDocumentationStartPage.ftl
+++ b/src/main/resources/templates/apidocumentation/apiDocumentationStartPage.ftl
@@ -31,6 +31,19 @@
       </p>
 
       <h2 class="govuk-heading-m" id="rate-limits">
+        Endpoints
+      </h2>
+      <p class="govuk-body">
+        Use the 'Endpoints' section of the menu <span class="els-non-mobile-only">on the left</span>
+        <span class="els-mobile-only">at the top</span> of this page to see what endpoints are available and
+        how to use them.
+      </p>
+
+      <p class="govuk-body">
+        The endpoints are also listed in <a href="${apiSpecUrl}" class="govuk-link" download>the energy label API OpenAPI 3 document</a>.
+      </p>
+
+      <h2 class="govuk-heading-m" id="rate-limits">
         Rate limits
       </h2>
       <p class="govuk-body">
@@ -55,7 +68,7 @@
         sandbox environment for testing. You can use the live API URL for development, testing and production.
       </p>
       <p class="govuk-body">
-        You can import <a href="${apiSpecUrl}" class="govuk-link">the energy label API OpenAPI 3 document</a> into API testing tools
+        You can import <a href="${apiSpecUrl}" class="govuk-link" download>the energy label API OpenAPI 3 document</a> into API testing tools
         like Postman to test all of our API endpoints.
       </p>
 
@@ -66,7 +79,7 @@
         These endpoints return data in PDF format for energy labels, PNG or JPEG for arrow images and JSON for errors.
       </p>
       <p class="govuk-body">
-        You can import <a href="${apiSpecUrl}" class="govuk-link">the energy label API OpenAPI 3 document</a> into API testing tools
+        You can import <a href="${apiSpecUrl}" class="govuk-link" download>the energy label API OpenAPI 3 document</a> into API testing tools
         like Postman to test all of our API endpoints.
       </p>
       <p class="govuk-body">


### PR DESCRIPTION
Added the paragraph to direct people to the endpoints in the menu, and updated the OpenAPI spec URL to make the filename more descriptive. `download` attributes added to OpenAPI links to force a file download rather than opening the JSON in the browser.