### PR TITLE
Add support for PNG/JPEG collation

### DIFF
--- a/src/main/java/uk/gov/beis/els/renderer/JpegRenderer.java
+++ b/src/main/java/uk/gov/beis/els/renderer/JpegRenderer.java
@@ -1,19 +1,24 @@
 package uk.gov.beis.els.renderer;
 
 import com.google.common.base.Stopwatch;
+import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.apache.batik.transcoder.TranscoderInput;
 import org.apache.batik.transcoder.TranscoderOutput;
 import org.apache.batik.transcoder.image.JPEGTranscoder;
 import org.apache.commons.io.IOUtils;
 import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
+import uk.gov.beis.els.util.RendererUtils;
 import uk.gov.beis.els.util.TemplateUtils;
 
 @Service
@@ -25,16 +30,31 @@ public class JpegRenderer implements Renderer {
   public Resource render(Document svg) {
     try {
       Stopwatch renderStopwatch = Stopwatch.createStarted();
-      TranscoderInput transcoderInput = new TranscoderInput(IOUtils.toInputStream(TemplateUtils.getSvgElement(svg).outerHtml(), "UTF-8"));
-
       ByteArrayOutputStream os = new ByteArrayOutputStream();
-      TranscoderOutput transcoderOutput = new TranscoderOutput(os);
-      JPEGTranscoder jpegTranscoder= new JPEGTranscoder();
-      jpegTranscoder.addTranscodingHint(JPEGTranscoder.KEY_QUALITY, 1f);
-      jpegTranscoder.transcode(transcoderInput, transcoderOutput);
 
-      LOGGER.info("JPEG internet label generated. Took [{}ms]", renderStopwatch.elapsed(TimeUnit.MILLISECONDS));
+      writeJpeg(svg, os);
 
+      LOGGER.info("JPEG label generated. Took [{}ms]", renderStopwatch.elapsed(TimeUnit.MILLISECONDS));
+      return new ByteArrayResource(os.toByteArray());
+
+    } catch (Exception e) {
+      throw new RuntimeException("Error generating JPEG from SVG", e);
+    }
+  }
+
+  @Override
+  public Resource render(List<Document> documents) {
+    try {
+      Stopwatch renderStopwatch = Stopwatch.createStarted();
+
+      ByteArrayOutputStream os = RendererUtils.applyImageCollation(
+          documents,
+          BufferedImage.TYPE_INT_RGB,
+          "jpeg",
+          this::writeJpeg
+      );
+
+      LOGGER.info("Collated JPEG label generated. Took [{}ms]", renderStopwatch.elapsed(TimeUnit.MILLISECONDS));
       return new ByteArrayResource(os.toByteArray());
 
     } catch (Exception e) {
@@ -45,6 +65,25 @@ public class JpegRenderer implements Renderer {
   @Override
   public MediaType getTargetContentType() {
     return MediaType.IMAGE_JPEG;
+  }
+
+  private void writeJpeg(Document svg, OutputStream outputStream) {
+    try {
+      Element svgElement = TemplateUtils.getSvgElement(svg);
+      TranscoderInput transcoderInput = new TranscoderInput(IOUtils.toInputStream(svgElement.outerHtml(), "UTF-8"));
+      TranscoderOutput transcoderOutput = new TranscoderOutput(outputStream);
+      JPEGTranscoder jpegTranscoder = new JPEGTranscoder();
+      jpegTranscoder.addTranscodingHint(JPEGTranscoder.KEY_QUALITY, 1f);
+
+      // If it's an energy label or fiche, set additional transcoder keys
+      if (!"internet-label".equals(svgElement.attr("data-type"))) {
+        RendererUtils.setRenderDimensions(jpegTranscoder, svg);
+      }
+
+      jpegTranscoder.transcode(transcoderInput, transcoderOutput);
+    } catch (Exception e) {
+      throw new RuntimeException("Error writing JPEG", e);
+    }
   }
 
 }

--- a/src/main/java/uk/gov/beis/els/renderer/JpegRenderer.java
+++ b/src/main/java/uk/gov/beis/els/renderer/JpegRenderer.java
@@ -11,7 +11,6 @@ import org.apache.batik.transcoder.TranscoderOutput;
 import org.apache.batik.transcoder.image.JPEGTranscoder;
 import org.apache.commons.io.IOUtils;
 import org.jsoup.nodes.Document;
-import org.jsoup.nodes.Element;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.ByteArrayResource;
@@ -69,14 +68,13 @@ public class JpegRenderer implements Renderer {
 
   private void writeJpeg(Document svg, OutputStream outputStream) {
     try {
-      Element svgElement = TemplateUtils.getSvgElement(svg);
-      TranscoderInput transcoderInput = new TranscoderInput(IOUtils.toInputStream(svgElement.outerHtml(), "UTF-8"));
+      TranscoderInput transcoderInput = new TranscoderInput(IOUtils.toInputStream(TemplateUtils.getSvgElement(svg).outerHtml(), "UTF-8"));
       TranscoderOutput transcoderOutput = new TranscoderOutput(outputStream);
       JPEGTranscoder jpegTranscoder = new JPEGTranscoder();
       jpegTranscoder.addTranscodingHint(JPEGTranscoder.KEY_QUALITY, 1f);
 
       // If it's an energy label or fiche, set additional transcoder keys
-      if (!"internet-label".equals(svgElement.attr("data-type"))) {
+      if (!TemplateUtils.isInternetLabel(svg)) {
         RendererUtils.setRenderDimensions(jpegTranscoder, svg);
       }
 

--- a/src/main/java/uk/gov/beis/els/renderer/PngRenderer.java
+++ b/src/main/java/uk/gov/beis/els/renderer/PngRenderer.java
@@ -13,7 +13,6 @@ import org.apache.batik.transcoder.image.ImageTranscoder;
 import org.apache.batik.transcoder.image.PNGTranscoder;
 import org.apache.commons.io.IOUtils;
 import org.jsoup.nodes.Document;
-import org.jsoup.nodes.Element;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.ByteArrayResource;
@@ -73,13 +72,12 @@ public class PngRenderer implements Renderer {
 
   private void writePng(Document svg, OutputStream outputStream) {
     try {
-      Element svgElement = TemplateUtils.getSvgElement(svg);
-      TranscoderInput transcoderInput = new TranscoderInput(IOUtils.toInputStream(svgElement.outerHtml(), "UTF-8"));
+      TranscoderInput transcoderInput = new TranscoderInput(IOUtils.toInputStream(TemplateUtils.getSvgElement(svg).outerHtml(), "UTF-8"));
       TranscoderOutput transcoderOutput = new TranscoderOutput(outputStream);
       PNGTranscoder pngTranscoder = new PNGTranscoder();
 
       // If it's an energy label or fiche, set additional transcoder keys
-      if (!"internet-label".equals(svgElement.attr("data-type"))) {
+      if (!TemplateUtils.isInternetLabel(svg)) {
         pngTranscoder.addTranscodingHint(ImageTranscoder.KEY_BACKGROUND_COLOR, Color.WHITE);
         RendererUtils.setRenderDimensions(pngTranscoder, svg);
       }

--- a/src/main/java/uk/gov/beis/els/renderer/PngRenderer.java
+++ b/src/main/java/uk/gov/beis/els/renderer/PngRenderer.java
@@ -1,19 +1,26 @@
 package uk.gov.beis.els.renderer;
 
 import com.google.common.base.Stopwatch;
+import java.awt.Color;
+import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.apache.batik.transcoder.TranscoderInput;
 import org.apache.batik.transcoder.TranscoderOutput;
+import org.apache.batik.transcoder.image.ImageTranscoder;
 import org.apache.batik.transcoder.image.PNGTranscoder;
 import org.apache.commons.io.IOUtils;
 import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
+import uk.gov.beis.els.util.RendererUtils;
 import uk.gov.beis.els.util.TemplateUtils;
 
 @Service
@@ -26,15 +33,11 @@ public class PngRenderer implements Renderer {
 
     try {
       Stopwatch renderStopwatch = Stopwatch.createStarted();
-      TranscoderInput transcoderInput = new TranscoderInput(IOUtils.toInputStream(TemplateUtils.getSvgElement(svg).outerHtml(), "UTF-8"));
-
       ByteArrayOutputStream os = new ByteArrayOutputStream();
-      TranscoderOutput transcoderOutput = new TranscoderOutput(os);
-      PNGTranscoder pngTranscoder = new PNGTranscoder();
-      pngTranscoder.transcode(transcoderInput, transcoderOutput);
+
+      writePng(svg, os);
 
       LOGGER.info("PNG internet label generated. Took [{}ms]", renderStopwatch.elapsed(TimeUnit.MILLISECONDS));
-
       return new ByteArrayResource(os.toByteArray());
 
     } catch (Exception e) {
@@ -44,8 +47,48 @@ public class PngRenderer implements Renderer {
   }
 
   @Override
+  public Resource render(List<Document> documents) {
+    try {
+      Stopwatch renderStopwatch = Stopwatch.createStarted();
+
+      ByteArrayOutputStream os = RendererUtils.applyImageCollation(
+          documents,
+          BufferedImage.TYPE_INT_ARGB,
+          "png",
+          this::writePng
+      );
+
+      LOGGER.info("Collated PNG label generated. Took [{}ms]", renderStopwatch.elapsed(TimeUnit.MILLISECONDS));
+      return new ByteArrayResource(os.toByteArray());
+
+    } catch (Exception e) {
+      throw new RuntimeException("Error generating PNG from SVG", e);
+    }
+  }
+
+  @Override
   public MediaType getTargetContentType() {
     return MediaType.IMAGE_PNG;
+  }
+
+  private void writePng(Document svg, OutputStream outputStream) {
+    try {
+      Element svgElement = TemplateUtils.getSvgElement(svg);
+      TranscoderInput transcoderInput = new TranscoderInput(IOUtils.toInputStream(svgElement.outerHtml(), "UTF-8"));
+      TranscoderOutput transcoderOutput = new TranscoderOutput(outputStream);
+      PNGTranscoder pngTranscoder = new PNGTranscoder();
+
+      // If it's an energy label or fiche, set additional transcoder keys
+      if (!"internet-label".equals(svgElement.attr("data-type"))) {
+        pngTranscoder.addTranscodingHint(ImageTranscoder.KEY_BACKGROUND_COLOR, Color.WHITE);
+        RendererUtils.setRenderDimensions(pngTranscoder, svg);
+      }
+
+      pngTranscoder.transcode(transcoderInput, transcoderOutput);
+    } catch (Exception e) {
+      throw new RuntimeException("Error writing PNG", e);
+    }
+
   }
 
 }

--- a/src/main/java/uk/gov/beis/els/renderer/Renderer.java
+++ b/src/main/java/uk/gov/beis/els/renderer/Renderer.java
@@ -1,5 +1,6 @@
 package uk.gov.beis.els.renderer;
 
+import java.util.List;
 import org.jsoup.nodes.Document;
 import org.springframework.core.io.Resource;
 import org.springframework.http.MediaType;
@@ -7,6 +8,8 @@ import org.springframework.http.MediaType;
 public interface Renderer {
 
   Resource render(Document html);
+
+  Resource render(List<Document> documents);
 
   MediaType getTargetContentType();
 

--- a/src/main/java/uk/gov/beis/els/util/RendererUtils.java
+++ b/src/main/java/uk/gov/beis/els/util/RendererUtils.java
@@ -1,0 +1,79 @@
+package uk.gov.beis.els.util;
+
+import java.awt.Graphics;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.util.List;
+import java.util.function.BiConsumer;
+import javax.imageio.ImageIO;
+import org.apache.batik.transcoder.image.ImageTranscoder;
+import org.jsoup.nodes.Document;
+
+public class RendererUtils {
+
+  /**
+   * Collate a list of SVG documents into a single image, using the provided image writer function.
+   * All images must be of the same dimension. They will be appended vertically.
+   * Image data is held in memory so care should be taken when calling this with a large number of images.
+   * @param documents List of SVG documents
+   * @param bufferedImageType The type of BufferedImage to create. E.g. BufferedImage.TYPE_INT_RGB
+   * @param imageIoFormatName The name of the ImageIO writer type, E.g. 'png' or 'jpeg'
+   * @param writerFunction The writer function. This will be called for each document.
+   * @return A ByteArrayOutputStream containing the collated image in the specified format.
+   */
+  public static ByteArrayOutputStream applyImageCollation(List<Document> documents, int bufferedImageType, String imageIoFormatName, BiConsumer<Document, OutputStream> writerFunction) {
+    try (ByteArrayOutputStream containerOs = new ByteArrayOutputStream()) {
+      // Get size from first doc
+      Document firstDocument = documents.get(0);
+      float width = TemplateUtils.getWidth(firstDocument);
+      float height = TemplateUtils.getHeight(firstDocument);
+
+      float scaledWidth = mmToPixels(width);
+      float scaledHeight = mmToPixels(height);
+
+      // Create a container image 'tall' enough for all documents
+      BufferedImage container = new BufferedImage(
+          Math.round(scaledWidth),
+          Math.round(scaledHeight * documents.size()),
+          bufferedImageType
+      );
+
+      Graphics containerGraphics = container.getGraphics();
+      int idx = 0;
+
+      for (Document doc : documents) {
+        try(ByteArrayOutputStream imageOs = new ByteArrayOutputStream()) {
+          writerFunction.accept(doc, imageOs);
+
+          BufferedImage image = ImageIO.read(new ByteArrayInputStream(imageOs.toByteArray()));
+          containerGraphics.drawImage(image, 0, Math.round(idx * scaledHeight), null);
+          idx++;
+        }
+      }
+
+      containerGraphics.dispose();
+      ImageIO.write(container, imageIoFormatName, containerOs);
+      return containerOs;
+    } catch (Exception e) {
+      throw new RuntimeException("Error collating images", e);
+    }
+  }
+
+  public static void setRenderDimensions(ImageTranscoder transcoder, Document doc) {
+    float width = TemplateUtils.getWidth(doc);
+    float height = TemplateUtils.getHeight(doc);
+
+    transcoder.addTranscodingHint(org.apache.batik.transcoder.image.ImageTranscoder.KEY_WIDTH, mmToPixels(width));
+    transcoder.addTranscodingHint(org.apache.batik.transcoder.image.ImageTranscoder.KEY_HEIGHT, mmToPixels(height));
+  }
+
+  private static float mmToInches(float mm) {
+    return mm * 0.03937f;
+  }
+
+  public static float mmToPixels(float mm) {
+    return mmToInches(mm) * 300; // 300 DPI
+  }
+}

--- a/src/main/java/uk/gov/beis/els/util/RendererUtils.java
+++ b/src/main/java/uk/gov/beis/els/util/RendererUtils.java
@@ -15,7 +15,7 @@ public class RendererUtils {
 
   /**
    * Collate a list of SVG documents into a single image, using the provided image writer function.
-   * All images must be of the same dimension. They will be appended vertically.
+   * All images must be of the same dimension. They will be appended horizontally.
    * Image data is held in memory so care should be taken when calling this with a large number of images.
    * @param documents List of SVG documents
    * @param bufferedImageType The type of BufferedImage to create. E.g. BufferedImage.TYPE_INT_RGB
@@ -33,10 +33,10 @@ public class RendererUtils {
       float scaledWidth = mmToPixels(width);
       float scaledHeight = mmToPixels(height);
 
-      // Create a container image 'tall' enough for all documents
+      // Create a container image wide enough for all documents
       BufferedImage container = new BufferedImage(
-          Math.round(scaledWidth),
-          Math.round(scaledHeight * documents.size()),
+          Math.round(scaledWidth * documents.size()),
+          Math.round(scaledHeight),
           bufferedImageType
       );
 
@@ -48,7 +48,7 @@ public class RendererUtils {
           writerFunction.accept(doc, imageOs);
 
           BufferedImage image = ImageIO.read(new ByteArrayInputStream(imageOs.toByteArray()));
-          containerGraphics.drawImage(image, 0, Math.round(idx * scaledHeight), null);
+          containerGraphics.drawImage(image, Math.round(idx * scaledWidth), 0, null);
           idx++;
         }
       }

--- a/src/main/java/uk/gov/beis/els/util/TemplateUtils.java
+++ b/src/main/java/uk/gov/beis/els/util/TemplateUtils.java
@@ -40,4 +40,12 @@ public class TemplateUtils {
     }
   }
 
+  public static float getWidth(Document doc) {
+    return Float.parseFloat(doc.body().attr("data-width"));
+  }
+
+  public static float getHeight(Document doc) {
+    return Float.parseFloat(doc.body().attr("data-height"));
+  }
+
 }

--- a/src/main/java/uk/gov/beis/els/util/TemplateUtils.java
+++ b/src/main/java/uk/gov/beis/els/util/TemplateUtils.java
@@ -40,12 +40,16 @@ public class TemplateUtils {
     }
   }
 
-  public static float getWidth(Document doc) {
-    return Float.parseFloat(doc.body().attr("data-width"));
+  public static float getWidth(Document document) {
+    return Float.parseFloat(document.body().attr("data-width"));
   }
 
-  public static float getHeight(Document doc) {
-    return Float.parseFloat(doc.body().attr("data-height"));
+  public static float getHeight(Document document) {
+    return Float.parseFloat(document.body().attr("data-height"));
+  }
+
+  public static boolean isInternetLabel(Document document) {
+    return "internet-label".equals(getSvgElement(document).attr("data-type"));
   }
 
 }

--- a/src/main/resources/fiches/space-heaters/boilerSpaceHeaterPackages.svg
+++ b/src/main/resources/fiches/space-heaters/boilerSpaceHeaterPackages.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" enable-background="new" version="1.1"
-     id="Layer_1" data-name="Layer 1" viewBox="0 0 744 1052" width="744" height="1052">
+     id="Layer_1" data-name="Layer 1" viewBox="0 0 744 1052" width="105" height="148">
 
   <defs id="defs4377">
     <style>

--- a/src/main/resources/fiches/space-heaters/cogenerationSpaceHeaterPackages.svg
+++ b/src/main/resources/fiches/space-heaters/cogenerationSpaceHeaterPackages.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 744 1052"
-     id="Layer_1" data-name="Layer 1" version="1.1" enable-background="new" width="744" height="1052">
+     id="Layer_1" data-name="Layer 1" version="1.1" enable-background="new" width="105" height="148">
   <defs id="defs4377">
 
     <style>

--- a/src/main/resources/fiches/space-heaters/heatPumpSpaceHeaterPackages.svg
+++ b/src/main/resources/fiches/space-heaters/heatPumpSpaceHeaterPackages.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 744 1052"
-     id="Layer_1" data-name="Layer 1" version="1.1" enable-background="new" width="744" height="1052">
+     id="Layer_1" data-name="Layer 1" version="1.1" enable-background="new" width="105" height="148">
   <defs id="defs4377">
     <style>
       .ficheTick {

--- a/src/main/resources/fiches/space-heaters/lowTemperatureHeatPumpSpaceHeaterPackages.svg
+++ b/src/main/resources/fiches/space-heaters/lowTemperatureHeatPumpSpaceHeaterPackages.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 744 1052"
-     id="Layer_1" data-name="Layer 1" version="1.1" enable-background="new" width="744" height="1052">
+     id="Layer_1" data-name="Layer 1" version="1.1" enable-background="new" width="105" height="148">
   <defs id="defs4377">
     <style>
       .ficheTick {

--- a/src/main/resources/fiches/water-heaters/packages-of-water-heater-and-solar-device-fiche.svg
+++ b/src/main/resources/fiches/water-heaters/packages-of-water-heater-and-solar-device-fiche.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" version="1.1"
-     id="Layer_1" data-name="Layer 1" viewBox="0 0 744 1052" width="744" height="1052">
+     id="Layer_1" data-name="Layer 1" viewBox="0 0 744 1052" width="105" height="148">
   <defs id="defs4377">
     <style>
       .ficheTick {

--- a/src/main/resources/labels/html-wrapper.html
+++ b/src/main/resources/labels/html-wrapper.html
@@ -47,6 +47,6 @@
     </style>
     <title id="html-title"></title>
   </head>
-  <body id="root">
+  <body id="root" data-width="${width}" data-height="${height}">
   </body>
 </html>

--- a/src/main/resources/labels/internet-labelling/internet-labelling-left.svg
+++ b/src/main/resources/labels/internet-labelling/internet-labelling-left.svg
@@ -1,4 +1,4 @@
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" width="391" height="158" viewBox="0 0 391 158">
+<svg id="Layer_1" data-name="Layer 1" data-type="internet-label" xmlns="http://www.w3.org/2000/svg" width="391" height="158" viewBox="0 0 391 158">
   <defs>
     <style>
       .cls-1 {

--- a/src/main/resources/labels/internet-labelling/internet-labelling-rescaled-bw-left.svg
+++ b/src/main/resources/labels/internet-labelling/internet-labelling-rescaled-bw-left.svg
@@ -1,4 +1,4 @@
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" width="367" height="201" viewBox="0 0 367 201">
+<svg id="Layer_1" data-name="Layer 1" data-type="internet-label" xmlns="http://www.w3.org/2000/svg" width="367" height="201" viewBox="0 0 367 201">
   <defs>
     <style>
       #range {

--- a/src/main/resources/labels/internet-labelling/internet-labelling-rescaled-bw-right.svg
+++ b/src/main/resources/labels/internet-labelling/internet-labelling-rescaled-bw-right.svg
@@ -1,4 +1,4 @@
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" width="367" height="201" viewBox="0 0 367 201">
+<svg id="Layer_1" data-name="Layer 1" data-type="internet-label" xmlns="http://www.w3.org/2000/svg" width="367" height="201" viewBox="0 0 367 201">
   <defs>
     <style>
       #range {

--- a/src/main/resources/labels/internet-labelling/internet-labelling-rescaled-left.svg
+++ b/src/main/resources/labels/internet-labelling/internet-labelling-rescaled-left.svg
@@ -1,4 +1,4 @@
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" width="367" height="201" viewBox="0 0 367 201">
+<svg id="Layer_1" data-name="Layer 1" data-type="internet-label" xmlns="http://www.w3.org/2000/svg" width="367" height="201" viewBox="0 0 367 201">
   <defs>
     <style>
       #range {

--- a/src/main/resources/labels/internet-labelling/internet-labelling-rescaled-right.svg
+++ b/src/main/resources/labels/internet-labelling/internet-labelling-rescaled-right.svg
@@ -1,4 +1,4 @@
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" width="367" height="201" viewBox="0 0 367 201">
+<svg id="Layer_1" data-name="Layer 1" data-type="internet-label" xmlns="http://www.w3.org/2000/svg" width="367" height="201" viewBox="0 0 367 201">
   <defs>
     <style>
       #range {

--- a/src/main/resources/labels/internet-labelling/internet-labelling-right.svg
+++ b/src/main/resources/labels/internet-labelling/internet-labelling-right.svg
@@ -1,4 +1,4 @@
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" width="391" height="158" viewBox="0 0 391 158">
+<svg id="Layer_1" data-name="Layer 1" data-type="internet-label" xmlns="http://www.w3.org/2000/svg" width="391" height="158" viewBox="0 0 391 158">
   <defs>
     <style>
       .cls-1 {

--- a/src/test/java/uk/gov/beis/els/service/DocumentRendererServiceTest.java
+++ b/src/test/java/uk/gov/beis/els/service/DocumentRendererServiceTest.java
@@ -89,7 +89,7 @@ public class DocumentRendererServiceTest {
   @Test
   public void testProcessImageResponse_Png() {
     ProcessedInternetLabelDocument doc = new ProcessedInternetLabelDocument(
-        Jsoup.parse("<svg id=\"Layer_1\" xmlns=\"http://www.w3.org/2000/svg\"></svg>"), "AP", ProductMetadata.DISHWASHERS, "x", "PNG", "y");
+        Jsoup.parse("<svg id=\"Layer_1\" xmlns=\"http://www.w3.org/2000/svg\" data-type=\"internet-label\"></svg>"), "AP", ProductMetadata.DISHWASHERS, "x", "PNG", "y");
 
     ResponseEntity responseEntity = documentRendererService.processImageResponse(doc);
 
@@ -102,7 +102,7 @@ public class DocumentRendererServiceTest {
   @Test
   public void testProcessImageResponse_Jpeg() {
     ProcessedInternetLabelDocument doc = new ProcessedInternetLabelDocument(
-        Jsoup.parse("<svg id=\"Layer_1\" xmlns=\"http://www.w3.org/2000/svg\"></svg>"), "AP", ProductMetadata.DISHWASHERS, "x", "JPEG", "y");
+        Jsoup.parse("<svg id=\"Layer_1\" xmlns=\"http://www.w3.org/2000/svg\" data-type=\"internet-label\"></svg>"), "AP", ProductMetadata.DISHWASHERS, "x", "JPEG", "y");
 
     ResponseEntity responseEntity = documentRendererService.processImageResponse(doc);
 


### PR DESCRIPTION
Implement collation of multiple SVGs into a single PNG or JPEG. This is required for image version of the fiche.
This can't currently be tested though the screens, that will be added next but didn't want to bloat out this PR massively.

All rasterisation is done at 300 DPI. Fiche SVGs have been sized down to 1/2 A4 as discussed.