### PR TITLE
Pass through output format and GA ID in package calculator forms

### DIFF
--- a/src/main/java/uk/gov/beis/els/categories/lamps/service/LampsService.java
+++ b/src/main/java/uk/gov/beis/els/categories/lamps/service/LampsService.java
@@ -150,6 +150,7 @@ public class LampsService {
     lampsForm.setEnergyConsumption(form.getEnergyConsumption());
     lampsForm.setSupplierName(form.getSupplierName());
     lampsForm.setModelName(form.getModelName());
+    lampsForm.setOutputFormat(form.getOutputFormat());
     return lampsForm;
   }
 
@@ -163,6 +164,7 @@ public class LampsService {
     lampsForm.setQrCodeUrl(form.getQrCodeUrl());
     lampsForm.setSupplierName(form.getSupplierName());
     lampsForm.setModelName(form.getModelName());
+    lampsForm.setOutputFormat(form.getOutputFormat());
     return lampsForm;
   }
 }

--- a/src/main/java/uk/gov/beis/els/categories/spaceheaters/service/SpaceHeatersService.java
+++ b/src/main/java/uk/gov/beis/els/categories/spaceheaters/service/SpaceHeatersService.java
@@ -491,6 +491,7 @@ public class SpaceHeatersService {
     form.setSupplierName(calculatorForm.getSupplierName());
     form.setModelName(calculatorForm.getModelName());
     form.setOutputFormat(calculatorForm.getOutputFormat());
+    form.setGoogleAnalyticsClientId(calculatorForm.getGoogleAnalyticsClientId());
     return form;
   }
 
@@ -534,5 +535,7 @@ public class SpaceHeatersService {
     combinationHeaterPackagesForm.setPackageSpaceHeatingEfficiencyRating(spaceHeaterPackagesForm.getPackageEfficiencyRating());
     combinationHeaterPackagesForm.setSupplierName(spaceHeaterPackagesCalculatorForm.getSupplierName());
     combinationHeaterPackagesForm.setModelName(spaceHeaterPackagesCalculatorForm.getModelName());
+    combinationHeaterPackagesForm.setOutputFormat(spaceHeaterPackagesForm.getOutputFormat());
+    combinationHeaterPackagesForm.setGoogleAnalyticsClientId(spaceHeaterPackagesForm.getGoogleAnalyticsClientId());
   }
 }

--- a/src/main/java/uk/gov/beis/els/categories/waterheaters/service/WaterHeatersService.java
+++ b/src/main/java/uk/gov/beis/els/categories/waterheaters/service/WaterHeatersService.java
@@ -134,6 +134,8 @@ public class WaterHeatersService {
       form.setWarmerGjAnnumBoth(heatPumpWaterHeatersApiForm.getWarmerGjAnnum());
     }
     form.setCanRunOffPeakOnly(heatPumpWaterHeatersApiForm.getCanRunOffPeakOnly());
+    form.setOutputFormat(heatPumpWaterHeatersApiForm.getOutputFormat());
+    form.setGoogleAnalyticsClientId(heatPumpWaterHeatersApiForm.getGoogleAnalyticsClientId());
     return form;
   }
 
@@ -187,6 +189,8 @@ public class WaterHeatersService {
     }
     form.setSoundPowerLevelIndoors(conventionalWaterHeaterApiForm.getSoundPowerLevelIndoors());
     form.setOffPeak(conventionalWaterHeaterApiForm.getOffPeak());
+    form.setOutputFormat(conventionalWaterHeaterApiForm.getOutputFormat());
+    form.setGoogleAnalyticsClientId(conventionalWaterHeaterApiForm.getGoogleAnalyticsClientId());
     return form;
   }
 
@@ -228,6 +232,8 @@ public class WaterHeatersService {
       form.setAverageGjAnnumBoth(solarWaterHeatersApiForm.getAverageGjAnnum());
       form.setWarmerGjAnnumBoth(solarWaterHeatersApiForm.getWarmerGjAnnum());
     }
+    form.setOutputFormat(solarWaterHeatersApiForm.getOutputFormat());
+    form.setGoogleAnalyticsClientId(solarWaterHeatersApiForm.getGoogleAnalyticsClientId());
     return form;
   }
 
@@ -254,6 +260,8 @@ public class WaterHeatersService {
     form.setStorageTank(waterSolarPackagesCalculatorForm.getStorageTank());
     form.setSupplierName(waterSolarPackagesCalculatorForm.getSupplierName());
     form.setModelName(waterSolarPackagesCalculatorForm.getModelName());
+    form.setOutputFormat(waterSolarPackagesCalculatorForm.getOutputFormat());
+    form.setGoogleAnalyticsClientId(waterSolarPackagesCalculatorForm.getGoogleAnalyticsClientId());
     return form;
   }
 
@@ -334,6 +342,8 @@ public class WaterHeatersService {
     waterSolarPackagesCalculatorForm.setSupplierName(boilerCombinationCalculatorForm.getSupplierName());
     waterSolarPackagesCalculatorForm.setModelName(boilerCombinationCalculatorForm.getModelName());
     waterSolarPackagesCalculatorForm.setOutputFormat(boilerCombinationCalculatorForm.getOutputFormat());
+    waterSolarPackagesCalculatorForm.setGoogleAnalyticsClientId(
+        boilerCombinationCalculatorForm.getGoogleAnalyticsClientId());
     return waterSolarPackagesCalculatorForm;
   }
 
@@ -351,6 +361,8 @@ public class WaterHeatersService {
     waterSolarPackagesCalculatorForm.setSupplierName(heatPumpCombinationCalculatorForm.getSupplierName());
     waterSolarPackagesCalculatorForm.setModelName(heatPumpCombinationCalculatorForm.getModelName());
     waterSolarPackagesCalculatorForm.setOutputFormat(heatPumpCombinationCalculatorForm.getOutputFormat());
+    waterSolarPackagesCalculatorForm.setGoogleAnalyticsClientId(
+        heatPumpCombinationCalculatorForm.getGoogleAnalyticsClientId());
     return waterSolarPackagesCalculatorForm;
   }
 

--- a/src/test/java/uk/gov/beis/els/categories/spaceheaters/service/SpaceHeatersServiceTest.java
+++ b/src/test/java/uk/gov/beis/els/categories/spaceheaters/service/SpaceHeatersServiceTest.java
@@ -1,10 +1,6 @@
 package uk.gov.beis.els.categories.spaceheaters.service;
 
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -17,6 +13,10 @@ import uk.gov.beis.els.categories.waterheaters.model.WaterSolarPackagesForm;
 import uk.gov.beis.els.categories.waterheaters.service.WaterHeatersService;
 import uk.gov.beis.els.model.RatingClass;
 import uk.gov.beis.els.service.TemplateParserService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SpaceHeatersServiceTest {
@@ -80,6 +80,9 @@ public class SpaceHeatersServiceTest {
     sourceForm.setSupplementaryHeatPumpHeatOutput("400");
     sourceForm.setSupplementaryHeatPumpSeasonalSpaceHeatingEfficiencyPercentage("65");
 
+    sourceForm.setOutputFormat("PNG");
+    sourceForm.setGoogleAnalyticsClientId("123");
+
     CombinationHeaterPackagesForm targetForm = spaceHeatersService.toCombinationHeaterPackagesForm(sourceForm);
 
     assertThat(targetForm.getSupplierName()).isEqualTo("supplier-name");
@@ -94,6 +97,8 @@ public class SpaceHeatersServiceTest {
     assertThat(targetForm.getHeaterDeclaredLoadProfile()).isEqualTo("XL");
     assertThat(targetForm.getPackageWaterHeatingEfficiencyRating()).isEqualTo("D");
     assertThat(targetForm.getPackageDeclaredLoadProfile()).isEqualTo("XL");
+    assertThat(targetForm.getOutputFormat()).isEqualTo("PNG");
+    assertThat(targetForm.getGoogleAnalyticsClientId()).isEqualTo("123");
   }
 
   @Test
@@ -116,6 +121,9 @@ public class SpaceHeatersServiceTest {
     sourceForm.setSpaceHeater(false);
     sourceForm.setSupplementaryHeatPump(false);
 
+    sourceForm.setOutputFormat("PNG");
+    sourceForm.setGoogleAnalyticsClientId("123");
+
     CombinationHeaterPackagesForm targetForm = spaceHeatersService.toCombinationHeaterPackagesForm(sourceForm);
 
     assertThat(targetForm.getSupplierName()).isEqualTo("supplier-name");
@@ -130,6 +138,8 @@ public class SpaceHeatersServiceTest {
     assertThat(targetForm.getHeaterDeclaredLoadProfile()).isEqualTo("M");
     assertThat(targetForm.getPackageWaterHeatingEfficiencyRating()).isEqualTo("D");
     assertThat(targetForm.getPackageDeclaredLoadProfile()).isEqualTo("M");
+    assertThat(targetForm.getOutputFormat()).isEqualTo("PNG");
+    assertThat(targetForm.getGoogleAnalyticsClientId()).isEqualTo("123");
   }
 
   @Test
@@ -163,6 +173,9 @@ public class SpaceHeatersServiceTest {
 
     sourceForm.setSpaceHeater(true);
 
+    sourceForm.setOutputFormat("PNG");
+    sourceForm.setGoogleAnalyticsClientId("123");
+
     CombinationHeaterPackagesForm targetForm = spaceHeatersService.toCombinationHeaterPackagesForm(sourceForm);
 
     assertThat(targetForm.getSupplierName()).isEqualTo("supplier-name");
@@ -177,6 +190,8 @@ public class SpaceHeatersServiceTest {
     assertThat(targetForm.getHeaterDeclaredLoadProfile()).isEqualTo("XL");
     assertThat(targetForm.getPackageWaterHeatingEfficiencyRating()).isEqualTo("D");
     assertThat(targetForm.getPackageDeclaredLoadProfile()).isEqualTo("XL");
+    assertThat(targetForm.getOutputFormat()).isEqualTo("PNG");
+    assertThat(targetForm.getGoogleAnalyticsClientId()).isEqualTo("123");
   }
 
   @Test
@@ -202,6 +217,9 @@ public class SpaceHeatersServiceTest {
     sourceForm.setStorageTank(false);
     sourceForm.setSpaceHeater(false);
 
+    sourceForm.setOutputFormat("PNG");
+    sourceForm.setGoogleAnalyticsClientId("123");
+
     CombinationHeaterPackagesForm targetForm = spaceHeatersService.toCombinationHeaterPackagesForm(sourceForm);
 
     assertThat(targetForm.getSupplierName()).isEqualTo("supplier-name");
@@ -216,6 +234,8 @@ public class SpaceHeatersServiceTest {
     assertThat(targetForm.getHeaterDeclaredLoadProfile()).isEqualTo("XL");
     assertThat(targetForm.getPackageWaterHeatingEfficiencyRating()).isEqualTo("D");
     assertThat(targetForm.getPackageDeclaredLoadProfile()).isEqualTo("XL");
+    assertThat(targetForm.getOutputFormat()).isEqualTo("PNG");
+    assertThat(targetForm.getGoogleAnalyticsClientId()).isEqualTo("123");
   }
 
 }


### PR DESCRIPTION
- Fix output format and GA ID not getting applied in some package calculator forms
- Fix some lamps API forms not using requested output format