### PR TITLE
Fix error when declining analytics cookies

### DIFF
--- a/src/main/resources/public/assets/scripts/cookieControl.js
+++ b/src/main/resources/public/assets/scripts/cookieControl.js
@@ -33,15 +33,21 @@
     denyConsentScripts: [
       // Google Analytics
       function() {
-        function gtag(){dataLayer.push(arguments);}
+        // dataLayer will only exist on window if they've already consented to analytics. If that's the case, we update
+        // consent preferences in the Google tag to ensure cookies aren't recreated
+        if(window.hasOwnProperty("dataLayer")) {
+          function gtag() {
+            dataLayer.push(arguments);
+          }
 
-        gtag("consent", "default", {
-          ad_storage: "denied",
-          analytics_storage: "denied",
-          functionality_storage: "denied",
-          personalization_storage: "denied",
-          security_storage: "denied"
-        });
+          gtag("consent", "default", {
+            ad_storage: "denied",
+            analytics_storage: "denied",
+            functionality_storage: "denied",
+            personalization_storage: "denied",
+            security_storage: "denied"
+          });
+        }
       }
     ],
     setCookie: function (name,value,days) {


### PR DESCRIPTION
The decline consent script was trying to push preferences to the Google tag in all cases, but this should only happen if they've previously granted consent for analytics - the GA `dataLayer` won't exist otherwise