### PR TITLE
Fix error when serving file download with unicode characters in the filename

### DIFF
--- a/src/main/java/uk/gov/beis/els/service/DocumentRendererService.java
+++ b/src/main/java/uk/gov/beis/els/service/DocumentRendererService.java
@@ -1,10 +1,12 @@
 package uk.gov.beis.els.service;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.jsoup.nodes.Document;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.Resource;
+import org.springframework.http.ContentDisposition;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -181,7 +183,7 @@ public class DocumentRendererService {
           .contentType(MediaType.APPLICATION_OCTET_STREAM)
           .contentLength(resource.contentLength())
           .header(
-              HttpHeaders.CONTENT_DISPOSITION, String.format("attachment; filename=\"%s\"", fileName))
+              HttpHeaders.CONTENT_DISPOSITION, ContentDisposition.attachment().filename(fileName, StandardCharsets.UTF_8).build().toString())
           .body(resource);
     } catch (Exception e) {
       throw new RuntimeException(String.format("Error serving file '%s'", fileName), e);

--- a/src/main/java/uk/gov/beis/els/util/ControllerUtils.java
+++ b/src/main/java/uk/gov/beis/els/util/ControllerUtils.java
@@ -6,10 +6,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
-import org.springframework.core.io.Resource;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.validation.ValidationUtils;
@@ -20,19 +16,6 @@ import uk.gov.beis.els.model.RatingClassRange;
 import uk.gov.beis.els.model.SelectableLegislationCategory;
 
 public class ControllerUtils {
-
-  public static ResponseEntity serveResource(Resource resource, String filename) {
-    try {
-      return ResponseEntity.ok()
-          .contentType(MediaType.APPLICATION_OCTET_STREAM)
-          .contentLength(resource.contentLength())
-          .header(
-              HttpHeaders.CONTENT_DISPOSITION, String.format("attachment; filename=\"%s\"", filename))
-          .body(resource);
-    } catch (Exception e) {
-      throw new RuntimeException(String.format("Error serving PDF file '%s'", filename), e);
-    }
-  }
 
   public static void addErrorSummary(ModelAndView modelAndView, List<FieldError> errorList) {
     modelAndView.addObject("errorList", errorList.stream()


### PR DESCRIPTION
Previously we wrote the generated filename directly into the content disposition header. As per RFC 9110 all headers must be ASCII, so if the filename contained unicode, Tomcat would drop the invalid header and the user would get a weird corrupt response due to the missing header.

This is fixed by using the Spring content disposition builder which handles re-encoding the filename as per RFC 5987.

See https://fivium.slack.com/archives/CGNCFH1D0/p1748429009178609?thread_ts=1748340174.570209&cid=CGNCFH1D0